### PR TITLE
Add Docker builds to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - amarthadan
+      - aquarat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,10 +56,10 @@ jobs:
         with:
           node-version: ${{ env.TARGET_NODE_VERSION }}
           cache: yarn
-      - name: Build docker image
+      - name: Build Docker image
         run: |
           docker build -t api3/airseeker-dev:${{ github.sha }} -f docker/Dockerfile .
-      - name: Login to DockerHub
+      - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           config-file: .github/workflows/mlc_config.json
 
   lint-build-test:
-    name: Lint, compile, test
+    name: Lint, build, test
     runs-on: ubuntu-latest
     # Don't run twice for a push within an internal PR
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -45,10 +45,32 @@ jobs:
         run: yarn build
       - name: Test
         run: yarn test
+  docker-build:
+    name: Build docker image and push to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Airseeker
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.TARGET_NODE_VERSION }}
+          cache: yarn
+      - name: Build docker image
+        run: |
+          docker build -t api3/airseeker-dev:${{ github.sha }} -f docker/Dockerfile .
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push built image
+        run: |
+          docker push api3/airseeker-dev:${{ github.sha }}
 
   required-checks-passed:
     name: All required checks passed
     runs-on: ubuntu-latest
-    needs: [documentation, lint-build-test]
+    needs: [documentation, lint-build-test, docker-build]
     steps:
       - run: exit 0


### PR DESCRIPTION
I can't remember the exact discussion but this PR adds Docker Hub builds to the CI.

Associated with this PR is also a new Docker Hub repository for these images: `api3/airseeker-dev:${COMMIT_HASH}`
