### PR TITLE
BEC-315:Fix where's the configuration loaded from in the container

### DIFF
--- a/airseeker-service.config.js
+++ b/airseeker-service.config.js
@@ -3,7 +3,7 @@ module.exports = {
   apps: [
     {
       name: 'airseeker',
-      script: './src/main.js',
+      script: './dist/main.js',
       kill_timeout: 10_000,
       env: {
         NODE_ENV: 'development',

--- a/airseeker-service.config.js
+++ b/airseeker-service.config.js
@@ -3,7 +3,7 @@ module.exports = {
   apps: [
     {
       name: 'airseeker',
-      script: './dist/src/main.js',
+      script: './src/main.js',
       kill_timeout: 10_000,
       env: {
         NODE_ENV: 'development',

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,9 @@ RUN yarn install && \
     yarn build && \
     yarn pack && \
     mkdir -p ${packageDir} && \
-    tar -xf *.tgz -C ${packageDir} --strip-components 1
+    tar -xf *.tgz -C ${packageDir} --strip-components 1 && \
+    cp -r ${packageDir}/dist/src ${packageDir} && \
+    rm -rf ${packageDir}/dist
 
 # Result image
 FROM environment

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,9 +40,7 @@ RUN yarn install && \
     yarn build && \
     yarn pack && \
     mkdir -p ${packageDir} && \
-    tar -xf *.tgz -C ${packageDir} --strip-components 1 && \
-    cp -r ${packageDir}/dist/src ${packageDir} && \
-    rm -rf ${packageDir}/dist
+    tar -xf *.tgz -C ${packageDir} --strip-components 1
 
 # Result image
 FROM environment

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "baseUrl": "./",
     "outDir": "./dist"
   },
-  "include": ["./src/**/*.ts", "./hardhat.config.ts"],
-  "exclude": ["node_modules"]
+  "include": ["./src/**/*.ts"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
I ended up moving the src folder out of dist folder inside the container to match the path of `__dirname` value when running Airseeker locally using `yarn start`
