### PR TITLE
Add Content-Type and Accept headers

### DIFF
--- a/src/make-request.ts
+++ b/src/make-request.ts
@@ -26,8 +26,12 @@ export const makeSignedDataGatewayRequests = async (
       const { data } = await axios({
         url: fullUrl,
         method: 'POST',
-        headers: { 'x-api-key': apiKey },
-        data: JSON.stringify({ encodedParameters: parameters }),
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'x-api-key': apiKey,
+        },
+        data: { encodedParameters: parameters },
         timeout: timeoutMs,
       });
 


### PR DESCRIPTION
You can test this by running GCP Airnode and making a request to it. You can use `make-request.feature.ts`. Use the following:

```
const mockedSignedDataGateway = {
  apiKey: '24aada5e-63f1-4a0b-8f8d-7d750d499f21',
  url: 'https://airnode-5e6f60d-dev-httpsigneddataapigateway-15phs1g0.ue.gateway.dev/',
  endpointId: '0xd9e8c9bcc8960df5f954c0817757d2f7f9601bd638ea2f94e890ae5481681153',
  parameters:
    '0x3173000000000000000000000000000000000000000000000000000000000000636f696e49640000000000000000000000000000000000000000000000000000626974636f696e00000000000000000000000000000000000000000000000000',
};
```