### PR TITLE
Unit & E2E tests for beacon updates

### DIFF
--- a/src/block-number.test.ts
+++ b/src/block-number.test.ts
@@ -1,0 +1,40 @@
+import { ethers } from 'ethers';
+import { getCurrentBlockNumber } from './block-number';
+import { initializeState } from './state';
+
+describe('getCurrentBlockNumber', () => {
+  const chainId = '31337';
+  const goOptions = {};
+
+  beforeEach(() => {
+    initializeState(null as any); // We don't need airseeker.json file
+  });
+
+  it('returns current block number', async () => {
+    const mockGetBlockNumber = jest.fn().mockImplementation(() => 42);
+    const provider = {
+      rpcProvider: {
+        getBlockNumber: mockGetBlockNumber,
+      } as unknown as ethers.providers.StaticJsonRpcProvider,
+      chainId,
+    };
+
+    const blockNumber = await getCurrentBlockNumber(provider, goOptions);
+    expect(blockNumber).toEqual(42);
+  });
+
+  it('returns null if current block number cannot be retrieved', async () => {
+    const mockGetBlockNumber = jest.fn().mockImplementation(() => {
+      throw new Error('Mock error');
+    });
+    const provider = {
+      rpcProvider: {
+        getBlockNumber: mockGetBlockNumber,
+      } as unknown as ethers.providers.StaticJsonRpcProvider,
+      chainId,
+    };
+
+    const blockNumber = await getCurrentBlockNumber(provider, goOptions);
+    expect(blockNumber).toBeNull();
+  });
+});

--- a/src/gas-prices.test.ts
+++ b/src/gas-prices.test.ts
@@ -1,0 +1,166 @@
+import { BigNumber, ethers } from 'ethers';
+import { PriorityFee } from '@api3/airnode-node';
+import * as state from './state';
+import * as gasPrices from './gas-prices';
+import { BASE_FEE_MULTIPLIER, PRIORITY_FEE_IN_WEI } from './constants';
+
+const setupMocks = () => {
+  jest.spyOn(ethers.providers, 'JsonRpcProvider').mockImplementation(
+    () =>
+      ({
+        getGasPrice: jest.fn(),
+        getBlock: jest.fn(),
+      } as unknown as ethers.providers.StaticJsonRpcProvider)
+  );
+  jest.spyOn(state, 'getState').mockImplementation(createMockState);
+};
+
+const createProvider = (chainId: string) => ({
+  rpcProvider: new ethers.providers.JsonRpcProvider(),
+  chainId,
+});
+
+const createMockState = () =>
+  ({
+    config: {
+      chains: {
+        '31337': {
+          options: {
+            txType: 'legacy',
+          },
+        },
+        '31331': {
+          options: {
+            txType: 'eip1559',
+            baseFeeMultiplier: BASE_FEE_MULTIPLIER,
+            priorityFee: {
+              value: 3.12,
+              unit: 'gwei',
+            },
+          },
+        },
+        '31332': {
+          options: {
+            txType: 'eip1559',
+            baseFeeMultiplier: undefined,
+            priorityFee: {
+              value: 3.12,
+              unit: 'gwei',
+            },
+          },
+        },
+        '31333': {
+          options: {
+            txType: 'eip1559',
+            baseFeeMultiplier: BASE_FEE_MULTIPLIER,
+            priorityFee: undefined,
+          },
+        },
+        '31334': {
+          options: {
+            txType: 'eip1559',
+            baseFeeMultiplier: undefined,
+            priorityFee: undefined,
+          },
+        },
+      },
+    },
+  } as unknown as state.State);
+
+const legacyChainId = '31337';
+const eip1559ChainIds = ['31331', '31332', '31333', '31334'];
+const goOptions = {};
+
+describe('parsePriorityFee', () => {
+  [
+    [{ value: 123, unit: 'wei' }, BigNumber.from('123')],
+    [{ value: 123 }, BigNumber.from('123')],
+    [{ value: 123.4, unit: 'kwei' }, BigNumber.from('123400')],
+    [{ value: 123.4, unit: 'mwei' }, BigNumber.from('123400000')],
+    [{ value: 123.4, unit: 'gwei' }, BigNumber.from('123400000000')],
+    [{ value: 123.4, unit: 'szabo' }, BigNumber.from('123400000000000')],
+    [{ value: 123.4, unit: 'finney' }, BigNumber.from('123400000000000000')],
+    [{ value: 123.4, unit: 'ether' }, BigNumber.from('123400000000000000000')],
+  ].forEach(([input, result], index) => {
+    it(`returns parsed wei from numbers - ${index}`, () => {
+      const priorityFeeInWei = gasPrices.parsePriorityFee(input as PriorityFee);
+      expect(priorityFeeInWei).toEqual(result);
+    });
+  });
+
+  [
+    { value: 3.12, unit: 'pence' },
+    { value: '3.1p', unit: 'gwei' },
+    { value: 3.12, unit: 'wei' },
+  ].forEach((input, index) => {
+    it(`throws an error for an invalid decimal denominated string, number and unit - ${index}`, () => {
+      const throwingFunction = () => gasPrices.parsePriorityFee(input as PriorityFee);
+      expect(throwingFunction).toThrow();
+    });
+  });
+});
+
+describe('getGasPrice', () => {
+  beforeEach(() => {
+    setupMocks();
+  });
+
+  const baseFeePerGas = ethers.BigNumber.from('93000000000');
+  const maxPriorityFeePerGas = BigNumber.from(PRIORITY_FEE_IN_WEI);
+  const maxFeePerGas = baseFeePerGas.mul(BASE_FEE_MULTIPLIER).add(maxPriorityFeePerGas);
+  const testGasPrice = ethers.BigNumber.from('48000000000');
+
+  eip1559ChainIds.forEach((chainId) => {
+    it(`returns the gas price from an EIP-1559 provider - chainId: ${chainId}`, async () => {
+      const provider = createProvider(chainId);
+      const getBlock = provider.rpcProvider.getBlock as jest.Mock;
+      getBlock.mockResolvedValueOnce({
+        baseFeePerGas,
+      });
+      const getGasPrice = provider.rpcProvider.getGasPrice as jest.Mock;
+
+      const gasPrice = (await gasPrices.getGasPrice(provider, goOptions)) as gasPrices.EIP1559GasTarget;
+      expect(gasPrice.maxPriorityFeePerGas).toEqual(maxPriorityFeePerGas);
+      expect(gasPrice.maxFeePerGas).toEqual(maxFeePerGas);
+      expect(getGasPrice).toHaveBeenCalledTimes(0);
+      expect(getBlock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('returns the gas price from a non-EIP-1559 provider', async () => {
+    const provider = createProvider(legacyChainId);
+    const getBlock = provider.rpcProvider.getBlock as jest.Mock;
+
+    const getGasPrice = provider.rpcProvider.getGasPrice as jest.Mock;
+    getGasPrice.mockResolvedValueOnce(testGasPrice);
+
+    const gasPrice = (await gasPrices.getGasPrice(provider, goOptions)) as gasPrices.LegacyGasTarget;
+    expect(gasPrice.gasPrice).toEqual(testGasPrice);
+    expect(getGasPrice).toHaveBeenCalledTimes(1);
+    expect(getBlock).toHaveBeenCalledTimes(0);
+  });
+
+  eip1559ChainIds.forEach((chainId) => {
+    it(`returns null if gas price from an EIP-1559 provider cannot be retrieved - chainId: ${chainId}`, async () => {
+      const provider = createProvider(chainId);
+      const getBlock = provider.rpcProvider.getBlock as jest.Mock;
+      getBlock.mockImplementation(() => {
+        throw new Error('Mock error');
+      });
+
+      const gasPrice = (await gasPrices.getGasPrice(provider, goOptions)) as gasPrices.EIP1559GasTarget;
+      expect(gasPrice).toBeNull();
+    });
+  });
+
+  it('returns null if gas price from a legacy provider cannot be retrieved', async () => {
+    const provider = createProvider(legacyChainId);
+    const getGasPrice = provider.rpcProvider.getGasPrice as jest.Mock;
+    getGasPrice.mockImplementation(() => {
+      throw new Error('Mock error');
+    });
+
+    const gasPrice = (await gasPrices.getGasPrice(provider, goOptions)) as gasPrices.LegacyGasTarget;
+    expect(gasPrice).toBeNull();
+  });
+});

--- a/src/gas-prices.ts
+++ b/src/gas-prices.ts
@@ -7,12 +7,12 @@ import { getState, Provider } from './state';
 import { PRIORITY_FEE_IN_WEI, BASE_FEE_MULTIPLIER } from './constants';
 import { logger } from './logging';
 
-type LegacyGasTarget = {
+export type LegacyGasTarget = {
   txType: 'legacy';
   gasPrice: BigNumber;
 };
 
-type EIP1559GasTarget = {
+export type EIP1559GasTarget = {
   txType: 'eip1559';
   maxPriorityFeePerGas: BigNumber;
   maxFeePerGas: BigNumber;

--- a/src/providers.test.ts
+++ b/src/providers.test.ts
@@ -1,0 +1,71 @@
+import * as state from './state';
+import { Config } from './validation';
+import { initializeProvider, initializeProviders } from './providers';
+
+describe('initializeProvider', () => {
+  it('returns initialized provider', () => {
+    const chainId = '5';
+    const providerUrl = 'http://127.0.0.1:8545/';
+
+    const provider = initializeProvider(chainId, providerUrl);
+    expect(provider.chainId).toEqual(chainId);
+    expect(provider.rpcProvider.connection.url).toEqual(providerUrl);
+  });
+});
+
+describe('initializeProviders', () => {
+  const config = {
+    chains: {
+      '1': {
+        providers: {
+          provider1: {
+            url: 'https://some.provider1.url',
+          },
+          provider2: {
+            url: 'https://some.provider2.url',
+          },
+        },
+      },
+      '3': {
+        providers: {
+          provider3: {
+            url: 'https://some.provider3.url',
+          },
+        },
+      },
+      '4': {
+        providers: {
+          provider4: {
+            url: 'https://some.provider4.url',
+          },
+        },
+      },
+    },
+    triggers: {
+      beaconUpdates: {
+        '1': {},
+        '2': {},
+        '3': {},
+      },
+    },
+  } as unknown as Config;
+  state.initializeState(config);
+
+  it('initialize providers', () => {
+    initializeProviders();
+
+    const { providers } = state.getState();
+
+    expect(Object.keys(providers)).toHaveLength(2);
+
+    const chain1Providers = providers['1'];
+    expect(chain1Providers).toHaveLength(2);
+    const chain1ProvidersUrls = chain1Providers.map((provider) => provider.rpcProvider.connection.url);
+    expect(chain1ProvidersUrls).toContain('https://some.provider1.url');
+    expect(chain1ProvidersUrls).toContain('https://some.provider2.url');
+
+    const chain3Providers = providers['3'];
+    expect(chain3Providers).toHaveLength(1);
+    expect(chain3Providers[0].rpcProvider.connection.url).toEqual('https://some.provider3.url');
+  });
+});

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,8 +1,8 @@
 import * as node from '@api3/airnode-node';
 import { logger } from './logging';
-import { getState, updateState, Providers } from './state';
+import { getState, updateState, Providers, Provider } from './state';
 
-const initializeProvider = (chainId: string, providerUrl: string) => {
+export const initializeProvider = (chainId: string, providerUrl: string): Provider => {
   const rpcProvider = node.evm.buildEVMProvider(providerUrl, chainId);
 
   return { rpcProvider, chainId };

--- a/src/transaction-count.test.ts
+++ b/src/transaction-count.test.ts
@@ -1,0 +1,35 @@
+import { ethers } from 'ethers';
+import { initializeState } from './state';
+import { getTransactionCount } from './transaction-count';
+
+describe('getTransactionCount', () => {
+  let rpcProvider: ethers.providers.StaticJsonRpcProvider;
+  const sponsorWalletAddress = '0x20557D8e841d7c2B12DBD45022B9147286F57691';
+  const blockNumber = 5;
+  const goOptions = {};
+
+  beforeEach(() => {
+    initializeState(null as any); // We don't need airseeker.json file
+  });
+
+  it('returns a transaction count', async () => {
+    rpcProvider = {
+      getTransactionCount: jest.fn().mockResolvedValue(10),
+    } as unknown as ethers.providers.StaticJsonRpcProvider;
+
+    const transactionCount = await getTransactionCount(rpcProvider, sponsorWalletAddress, blockNumber, goOptions);
+    expect(transactionCount).toEqual(10);
+    expect(rpcProvider.getTransactionCount).toHaveBeenCalledWith(sponsorWalletAddress, blockNumber);
+  });
+
+  it('returns null if transaction count cannot be retrieved', async () => {
+    rpcProvider = {
+      getTransactionCount: jest.fn().mockImplementation(() => {
+        throw new Error('Mock error');
+      }),
+    } as unknown as ethers.providers.StaticJsonRpcProvider;
+
+    const transactionCount = await getTransactionCount(rpcProvider, sponsorWalletAddress, blockNumber, goOptions);
+    expect(transactionCount).toBeNull();
+  });
+});

--- a/src/update-beacons.test.ts
+++ b/src/update-beacons.test.ts
@@ -1,7 +1,266 @@
 import { ethers } from 'ethers';
 import { logger } from './logging';
-import { readOnChainBeaconData } from './update-beacons';
+import * as state from './state';
+import { BeaconUpdate, Config } from './validation';
+import { initializeProviders } from './providers';
+import * as api from './update-beacons';
+import { DEFAULT_LOG_OPTIONS } from './constants';
 import { getUnixTimestamp } from '../test/fixtures';
+
+const config: Config = {
+  airseekerWalletMnemonic: 'achieve climb couple wait accident symbol spy blouse reduce foil echo label',
+  beacons: {
+    '0x2ba0526238b0f2671b7981fd7a263730619c8e849a528088fd4a92350a8c2f2c': {
+      airnode: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+      templateId: '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa',
+      fetchInterval: 25,
+    },
+    '0xa5ddf304a7dcec62fa55449b7fe66b33339fd8b249db06c18423d5b0da7716c2': {
+      airnode: '0x5656D3A378B1AAdFDDcF4196ea364A9d78617290',
+      templateId: '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa',
+      // Artificially low interval to make the tests run fast without mocking
+      fetchInterval: 0.5,
+    },
+    '0x8fa9d00cb8f2d95b1299623d97a97696ed03d0e3350e4ea638f469be4d6f214e': {
+      airnode: '0x5656D3A378B1AAdFDDcF4196ea364A9d78617290',
+      templateId: '0x9ec34b00a5019442dcd05a4860ff2bf015164b368cb83fcb756088fc6fbd6480',
+      fetchInterval: 40,
+    },
+    '0x8fa9d00cb8f2d95b1299623d97a97696ed03d0e3350e4ea638f469beabcdabcd': {
+      airnode: '0x5656D3A378B1AAdFDDcF4196ea364A9d78617290',
+      templateId: '0x9ec34b00a5019442dcd05a4860ff2bf015164b368cb83fcb756088fcabcdabcd',
+      fetchInterval: 40,
+    },
+  },
+  beaconSets: {},
+  chains: {
+    '1': {
+      contracts: {
+        DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+      },
+      providers: {
+        selfHostedMainnet: {
+          url: 'https://some.self.hosted.mainnet.url',
+        },
+        infuraMainnet: {
+          url: 'https://some.infura.mainnet.url',
+        },
+      },
+      options: {
+        txType: 'eip1559',
+        priorityFee: {
+          value: 3.12,
+          unit: 'gwei',
+        },
+        baseFeeMultiplier: 2,
+      },
+    },
+    '3': {
+      contracts: {
+        DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+      },
+      providers: {
+        infuraRopsten: {
+          url: 'https://some.influra.ropsten.url',
+        },
+      },
+      options: {
+        txType: 'eip1559',
+        priorityFee: {
+          value: 3.12,
+          unit: 'gwei',
+        },
+        baseFeeMultiplier: 2,
+      },
+    },
+  },
+  gateways: {
+    '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace': [
+      {
+        apiKey: '18e06827-8544-4b0f-a639-33df3b5bc62f',
+        url: 'https://some.http.signed.data.gateway.url/',
+      },
+    ],
+    '0x5656D3A378B1AAdFDDcF4196ea364A9d78617290': [
+      {
+        apiKey: '18e06827-8544-4b0f-a639-33df3b5bc62f',
+        url: 'https://another.http.signed.data.gateway.url/',
+      },
+    ],
+  },
+  templates: {
+    '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa': {
+      endpointId: '0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6',
+      parameters:
+        '0x3173737373730000000000000000000000000000000000000000000000000000746f00000000000000000000000000000000000000000000000000000000000055534400000000000000000000000000000000000000000000000000000000005f74797065000000000000000000000000000000000000000000000000000000696e7432353600000000000000000000000000000000000000000000000000005f70617468000000000000000000000000000000000000000000000000000000726573756c7400000000000000000000000000000000000000000000000000005f74696d65730000000000000000000000000000000000000000000000000000313030303030300000000000000000000000000000000000000000000000000066726f6d000000000000000000000000000000000000000000000000000000004554480000000000000000000000000000000000000000000000000000000000',
+    },
+    '0x9ec34b00a5019442dcd05a4860ff2bf015164b368cb83fcb756088fc6fbd6480': {
+      endpointId: '0xfa102bdb25c5358994a6213ddccdd27a0f310bf4a4d755e29bb74230f91a9d50',
+      parameters:
+        '0x3173737373730000000000000000000000000000000000000000000000000000746f00000000000000000000000000000000000000000000000000000000000055534400000000000000000000000000000000000000000000000000000000005f74797065000000000000000000000000000000000000000000000000000000696e7432353600000000000000000000000000000000000000000000000000005f70617468000000000000000000000000000000000000000000000000000000726573756c7400000000000000000000000000000000000000000000000000005f74696d65730000000000000000000000000000000000000000000000000000313030303030300000000000000000000000000000000000000000000000000066726f6d000000000000000000000000000000000000000000000000000000004554480000000000000000000000000000000000000000000000000000000000',
+    },
+    '0x9ec34b00a5019442dcd05a4860ff2bf015164b368cb83fcb756088fcabcdabcd': {
+      endpointId: '0xfa102bdb25c5358994a6213ddccdd27a0f310bf4a4d755e29bb74230f91a9d50',
+      parameters:
+        '0x3173737373730000000000000000000000000000000000000000000000000000746f00000000000000000000000000000000000000000000000000000000000055534400000000000000000000000000000000000000000000000000000000005f74797065000000000000000000000000000000000000000000000000000000696e7432353600000000000000000000000000000000000000000000000000005f70617468000000000000000000000000000000000000000000000000000000726573756c7400000000000000000000000000000000000000000000000000005f74696d65730000000000000000000000000000000000000000000000000000313030303030300000000000000000000000000000000000000000000000000066726f6d000000000000000000000000000000000000000000000000000000004554480000000000000000000000000000000000000000000000000000000000',
+    },
+  },
+  triggers: {
+    beaconUpdates: {
+      '1': {
+        '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC': {
+          beacons: [
+            {
+              beaconId: '0x2ba0526238b0f2671b7981fd7a263730619c8e849a528088fd4a92350a8c2f2c',
+              deviationThreshold: 0.1,
+              heartbeatInterval: 86_400,
+            },
+            {
+              beaconId: '0xa5ddf304a7dcec62fa55449b7fe66b33339fd8b249db06c18423d5b0da7716c2',
+              deviationThreshold: 0.7,
+              heartbeatInterval: 15_000,
+            },
+          ],
+          // Artificially low interval to make the tests run fast without mocking
+          updateInterval: 1,
+        },
+      },
+      '3': {
+        '0x417B205fEdB1b2352c7996B0F050A7a61544c5e2': {
+          beacons: [
+            {
+              beaconId: '0x2ba0526238b0f2671b7981fd7a263730619c8e849a528088fd4a92350a8c2f2c',
+              deviationThreshold: 0.2,
+              heartbeatInterval: 86_400,
+            },
+          ],
+          updateInterval: 40,
+        },
+      },
+    },
+    beaconSetUpdates: {},
+  },
+};
+state.initializeState(config);
+initializeProviders();
+
+// Can't compare RPC provider instances so comparing groups where the provider is represented by its URL
+type ComparableProviderSponsorBeacons = {
+  provider: string;
+  sponsorAddress: string;
+  updateInterval: number;
+  beacons: BeaconUpdate[];
+};
+
+const cpsbg: ComparableProviderSponsorBeacons[] = [
+  {
+    provider: 'https://some.self.hosted.mainnet.url',
+    sponsorAddress: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+    updateInterval: 1,
+    beacons: config.triggers.beaconUpdates['1']['0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'].beacons,
+  },
+  {
+    provider: 'https://some.infura.mainnet.url',
+    sponsorAddress: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+    updateInterval: 1,
+    beacons: config.triggers.beaconUpdates['1']['0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'].beacons,
+  },
+  {
+    provider: 'https://some.influra.ropsten.url',
+    sponsorAddress: '0x417B205fEdB1b2352c7996B0F050A7a61544c5e2',
+    updateInterval: 40,
+    beacons: config.triggers.beaconUpdates['3']['0x417B205fEdB1b2352c7996B0F050A7a61544c5e2'].beacons,
+  },
+];
+
+describe('groupBeaconsByProviderSponsor', () => {
+  it('groups beacons by provider+sponsor pair', () => {
+    const providerSponsorBeaconsGroups = api.groupBeaconsByProviderSponsor();
+    const comparableProviderSponsorBeaconsGroups = providerSponsorBeaconsGroups.map((psbg) => ({
+      ...psbg,
+      provider: psbg.provider.rpcProvider.connection.url,
+    }));
+
+    expect(providerSponsorBeaconsGroups).toHaveLength(3);
+    expect(comparableProviderSponsorBeaconsGroups).toContainEqual(cpsbg[0]);
+    expect(comparableProviderSponsorBeaconsGroups).toContainEqual(cpsbg[1]);
+    expect(comparableProviderSponsorBeaconsGroups).toContainEqual(cpsbg[2]);
+  });
+});
+
+describe('initiateBeaconUpdates', () => {
+  it('initiates beacon updates', async () => {
+    const comparableProviderSponsorBeaconsGroups: ComparableProviderSponsorBeacons[] = [];
+    jest.spyOn(api, 'updateBeaconsInLoop').mockImplementation(async (group) => {
+      comparableProviderSponsorBeaconsGroups.push({ ...group, provider: group.provider.rpcProvider.connection.url });
+    });
+
+    api.initiateBeaconUpdates();
+    expect(comparableProviderSponsorBeaconsGroups).toHaveLength(3);
+    expect(comparableProviderSponsorBeaconsGroups).toContainEqual(cpsbg[0]);
+    expect(comparableProviderSponsorBeaconsGroups).toContainEqual(cpsbg[1]);
+    expect(comparableProviderSponsorBeaconsGroups).toContainEqual(cpsbg[2]);
+  });
+});
+
+describe('updateBeaconsInLoop', () => {
+  it('calls updateBeacons in a loop', async () => {
+    const groups = api.groupBeaconsByProviderSponsor();
+    let requestCount = 0;
+    jest.spyOn(api, 'updateBeacons').mockImplementation(async () => {
+      requestCount++;
+    });
+    jest.spyOn(state, 'getState').mockImplementation(() => {
+      if (requestCount === 2) {
+        return {
+          config,
+          stopSignalReceived: true,
+          beaconValues: {},
+          providers: {},
+          logOptions: DEFAULT_LOG_OPTIONS,
+        };
+      } else {
+        return {
+          config,
+          stopSignalReceived: false,
+          beaconValues: {},
+          providers: {},
+          logOptions: DEFAULT_LOG_OPTIONS,
+        };
+      }
+    });
+
+    await api.updateBeaconsInLoop(groups[0]);
+
+    expect(api.updateBeacons).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('calculateTimeout', () => {
+  it('calculates the remaining time for timeout', () => {
+    const startTime = 1650548022000;
+    const totalTimeout = 3000;
+    jest.spyOn(Date, 'now').mockReturnValue(1650548023000);
+
+    expect(api.calculateTimeout(startTime, totalTimeout)).toEqual(2000);
+  });
+});
+
+describe('prepareGoOptions', () => {
+  it('prepares options for the go function', () => {
+    const startTime = 1650548022000;
+    const totalTimeout = 3000;
+    jest.spyOn(Date, 'now').mockReturnValue(1650548023000);
+
+    const expectedGoOptions = {
+      attemptTimeoutMs: 5_000,
+      totalTimeoutMs: 2000,
+      retries: 100_000,
+      delay: { type: 'random' as const, minDelayMs: 0, maxDelayMs: 2_500 },
+    };
+    expect(api.prepareGoOptions(startTime, totalTimeout)).toEqual(expectedGoOptions);
+  });
+});
 
 it('readOnChainBeaconData', async () => {
   jest.spyOn(logger, 'log');
@@ -25,7 +284,7 @@ it('readOnChainBeaconData', async () => {
     new ethers.providers.JsonRpcProvider(providerUrl)
   );
 
-  const onChainBeaconData = await readOnChainBeaconData(voidSigner, dapiServer, 'some-id', { retries: 100_000 });
+  const onChainBeaconData = await api.readOnChainBeaconData(voidSigner, dapiServer, 'some-id', { retries: 100_000 });
 
   expect(onChainBeaconData).toEqual(feedValue);
   expect(logger.log).toHaveBeenCalledTimes(2);

--- a/src/update-beacons.ts
+++ b/src/update-beacons.ts
@@ -29,7 +29,7 @@ type ProviderSponsorBeacons = {
   beacons: BeaconUpdate[];
 };
 
-const groupBeaconsByProviderSponsor = () => {
+export const groupBeaconsByProviderSponsor = () => {
   const { config, providers: stateProviders } = getState();
   return Object.entries(config.triggers.beaconUpdates).reduce((acc: ProviderSponsorBeacons[], [chainId, sponsors]) => {
     const providers = stateProviders[chainId];
@@ -89,11 +89,11 @@ export const updateBeaconsInLoop = async (providerSponsorBeacons: ProviderSponso
   }
 };
 
-const calculateTimeout = (startTime: number, totalTimeout: number) => totalTimeout - (Date.now() - startTime);
+export const calculateTimeout = (startTime: number, totalTimeout: number) => totalTimeout - (Date.now() - startTime);
 
 // We retry all chain operations with a random back-off infinitely until the next updates cycle
 // TODO: Errors are not displayed with this approach. Problem?
-const prepareGoOptions = (startTime: number, totalTimeout: number): GoAsyncOptions => ({
+export const prepareGoOptions = (startTime: number, totalTimeout: number): GoAsyncOptions => ({
   attemptTimeoutMs: PROVIDER_TIMEOUT_MS,
   totalTimeoutMs: calculateTimeout(startTime, totalTimeout),
   retries: INFINITE_RETRIES,

--- a/test/e2e/update-beacons.feature.ts
+++ b/test/e2e/update-beacons.feature.ts
@@ -1,0 +1,60 @@
+import { ethers } from 'ethers';
+import * as hre from 'hardhat';
+import { DapiServer__factory as DapiServerFactory } from '@api3/airnode-protocol-v1';
+import { initiateBeaconUpdates } from '../../src/update-beacons';
+import * as utils from '../../src/utils';
+import * as state from '../../src/state';
+import { initializeProviders } from '../../src/providers';
+import { deployAndUpdateSubscriptions } from '../setup/deployment';
+import { buildAirseekerConfig, buildLocalSecrets } from '../fixtures/config';
+import { SignedData } from '../../src/validation';
+import { parseConfigWithSecrets } from '../../src/config';
+
+// Jest version 27 has a bug where jest.setTimeout does not work correctly inside describe or test blocks
+// https://github.com/facebook/jest/issues/11607
+jest.setTimeout(60_000);
+
+const providerUrl = 'http://127.0.0.1:8545/';
+const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
+const dapiServer = DapiServerFactory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
+let signedData: SignedData;
+
+describe('updateBeacons', () => {
+  beforeAll(async () => {
+    // Reset the local hardhat network state for each test to prevent issues with other test contracts
+    await hre.network.provider.send('hardhat_reset');
+    jest.restoreAllMocks();
+
+    const { signedData: preparedSignedData } = await deployAndUpdateSubscriptions();
+    signedData = preparedSignedData;
+    const config = parseConfigWithSecrets(buildAirseekerConfig(), buildLocalSecrets());
+    if (!config.success) {
+      throw new Error('Invalid configuration fixture');
+    }
+    state.initializeState(config.data);
+    initializeProviders();
+  });
+
+  beforeEach(() => {
+    const beaconValues1 = {
+      '0x924b5d4cb3ec6366ae4302a1ca6aec035594ea3ea48a102d160b50b0c43ebfb5': signedData,
+    };
+
+    state.updateState((oldState) => ({ ...oldState, beaconValues: beaconValues1 }));
+  });
+
+  it('updates beacons based on the configuration', async () => {
+    initiateBeaconUpdates();
+    await utils.sleep(3_000);
+    state.updateState((oldState) => ({ ...oldState, stopSignalReceived: true }));
+    await utils.sleep(3_000);
+
+    const beaconData = await dapiServer
+      .connect(voidSigner)
+      .readDataFeedValueWithId('0x924b5d4cb3ec6366ae4302a1ca6aec035594ea3ea48a102d160b50b0c43ebfb5');
+    expect(beaconData.toString()).toEqual('738149047');
+  });
+
+  // TODO: Add more tests
+});


### PR DESCRIPTION
I know that the E2E test is a weak one but it took me a stupid amount of time to make sure all the IDs are in sync and I want to move on. We have https://github.com/api3dao/airseeker/pull/31 anyway and we can add more tests later.

I had to add `--runInBand` for E2E tests so they run sequentially because otherwise the chain resets messed up unrelated tests.