### PR TITLE
Fix bad JS math

### DIFF
--- a/src/check-condition.test.ts
+++ b/src/check-condition.test.ts
@@ -136,4 +136,10 @@ describe('checkUpdateCondition', () => {
     expect(readDataFeedWithIdSpy).toHaveBeenNthCalledWith(1, beaconId);
     expect(checkUpdateConditionResult).toBeNull();
   });
+
+  it('handles correctly bad JS math', async () => {
+    await expect(
+      checkUpdateCondition(voidSigner, dapiServerMock as any, beaconId, 0.14, ethers.BigNumber.from(560), goOptions)
+    ).resolves.not.toThrow();
+  });
 });

--- a/src/check-condition.ts
+++ b/src/check-condition.ts
@@ -37,7 +37,9 @@ export const checkUpdateCondition = async (
 
   const [dapiServerValue, _timestamp] = goDataFeed.data;
   const updateInPercentage = calculateUpdateInPercentage(dapiServerValue, apiValue);
-  const threshold = ethers.BigNumber.from(deviationThreshold * HUNDRED_PERCENT).div(ethers.BigNumber.from(100));
+  const threshold = ethers.BigNumber.from(Math.trunc(deviationThreshold * HUNDRED_PERCENT)).div(
+    ethers.BigNumber.from(100)
+  );
 
   return updateInPercentage.gt(threshold);
 };


### PR DESCRIPTION
When playing with Airseeker I run into this exceptionL
`[Error: underflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-underflow ] (fault="underflow", operation="BigNumber.from", value=14000000.000000002, code=NUMERIC_FAULT, version=bignumber/5.6.0)]`
It's happening because JS math is horrible and doing for example `1e8 * 0.14` results in `14000000.000000002` which when passed to `ethers.BigNumber.from` causes an exception.