### PR TITLE
Add check that the signed data are not older than data on-chain

### DIFF
--- a/src/check-condition.test.ts
+++ b/src/check-condition.test.ts
@@ -1,7 +1,14 @@
-import { ethers } from 'ethers';
-import { calculateUpdateInPercentage, checkUpdateCondition, HUNDRED_PERCENT } from './check-condition';
+import { BigNumber, ethers } from 'ethers';
+import {
+  calculateUpdateInPercentage,
+  checkSignedDataFreshness,
+  checkUpdateCondition,
+  HUNDRED_PERCENT,
+  OnChainBeaconData,
+} from './check-condition';
 import { DEFAULT_LOG_OPTIONS } from './constants';
 import { State, updateState } from './state';
+import { getUnixTimestamp, validSignedData } from '../test/fixtures';
 
 updateState((_state) => ({ logOptions: DEFAULT_LOG_OPTIONS } as unknown as State));
 
@@ -53,93 +60,50 @@ describe('calculateUpdateInPercentage', () => {
 });
 
 describe('checkUpdateCondition', () => {
-  const providerUrl = 'http://127.0.0.1:8545/';
-  const beaconId = '0x2ba0526238b0f2671b7981fd7a263730619c8e849a528088fd4a92350a8c2f2c';
-  const provider = new ethers.providers.JsonRpcProvider(providerUrl);
-  const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-  const goOptions = {};
-
-  let readDataFeedWithIdSpy: jest.Mock;
-  let dapiServerMock: {
-    connect(_signerOrProvider: ethers.Signer | ethers.providers.Provider | string): typeof dapiServerMock;
-    readDataFeedWithId: jest.Mock;
+  const onChainData: OnChainBeaconData = {
+    value: ethers.BigNumber.from(500),
+    timestamp: getUnixTimestamp('2019-3-21'),
   };
 
-  beforeEach(() => {
-    const readDataFeedWithIdMock = () => Promise.resolve([ethers.BigNumber.from(500)]);
-    readDataFeedWithIdSpy = jest.fn().mockImplementation(readDataFeedWithIdMock);
-    dapiServerMock = {
-      connect(_signerOrProvider: ethers.Signer | ethers.providers.Provider | string) {
-        return this;
-      },
-      readDataFeedWithId: readDataFeedWithIdSpy,
-    };
-  });
-
   it('reads dapiserver value and checks the threshold condition to be true for increase', async () => {
-    const checkUpdateConditionResult = await checkUpdateCondition(
-      voidSigner,
-      dapiServerMock as any,
-      beaconId,
-      10,
-      ethers.BigNumber.from(560),
-      goOptions
-    );
+    const shouldUpdate = await checkUpdateCondition(onChainData, 10, ethers.BigNumber.from(560));
 
-    expect(readDataFeedWithIdSpy).toHaveBeenNthCalledWith(1, beaconId);
-    expect(checkUpdateConditionResult).toEqual(true);
+    expect(shouldUpdate).toEqual(true);
   });
 
   it('reads dapiserver value and checks the threshold condition to be true for decrease', async () => {
-    const checkUpdateConditionResult = await checkUpdateCondition(
-      voidSigner,
-      dapiServerMock as any,
-      beaconId,
-      10,
-      ethers.BigNumber.from(440),
-      goOptions
-    );
+    const shouldUpdate = await checkUpdateCondition(onChainData, 10, ethers.BigNumber.from(440));
 
-    expect(readDataFeedWithIdSpy).toHaveBeenNthCalledWith(1, beaconId);
-    expect(checkUpdateConditionResult).toEqual(true);
+    expect(shouldUpdate).toEqual(true);
   });
 
   it('reads dapiserver value and checks the threshold condition to be false', async () => {
-    const checkUpdateConditionResult = await checkUpdateCondition(
-      voidSigner,
-      dapiServerMock as any,
-      beaconId,
-      10,
-      ethers.BigNumber.from(480),
-      goOptions
-    );
+    const shouldUpdate = await checkUpdateCondition(onChainData, 10, ethers.BigNumber.from(480));
 
-    expect(readDataFeedWithIdSpy).toHaveBeenNthCalledWith(1, beaconId);
-    expect(checkUpdateConditionResult).toEqual(false);
-  });
-
-  it('returns null if it is not able to fetch the data feed', async () => {
-    readDataFeedWithIdSpy = jest.fn().mockImplementation(() => {
-      throw new Error('Mock error');
-    });
-    dapiServerMock = { ...dapiServerMock, readDataFeedWithId: readDataFeedWithIdSpy };
-
-    const checkUpdateConditionResult = await checkUpdateCondition(
-      voidSigner,
-      dapiServerMock as any,
-      beaconId,
-      10,
-      ethers.BigNumber.from(560),
-      goOptions
-    );
-
-    expect(readDataFeedWithIdSpy).toHaveBeenNthCalledWith(1, beaconId);
-    expect(checkUpdateConditionResult).toBeNull();
+    expect(shouldUpdate).toEqual(false);
   });
 
   it('handles correctly bad JS math', async () => {
-    await expect(
-      checkUpdateCondition(voidSigner, dapiServerMock as any, beaconId, 0.14, ethers.BigNumber.from(560), goOptions)
-    ).resolves.not.toThrow();
+    await expect(checkUpdateCondition(onChainData, 0.14, ethers.BigNumber.from(560))).resolves.not.toThrow();
+  });
+});
+
+describe('checkSignedDataFreshness', () => {
+  it('returns true if signed data gateway is newer then on chain record', () => {
+    const isFresh = checkSignedDataFreshness(
+      { value: BigNumber.from('123'), timestamp: getUnixTimestamp('2022-4-28') },
+      validSignedData
+    );
+
+    expect(isFresh).toBe(false);
+  });
+
+  it('returns false if signed data gateway is older then on chain record', () => {
+    const isFresh = checkSignedDataFreshness(
+      { value: BigNumber.from('123'), timestamp: getUnixTimestamp('2019-4-28') },
+      validSignedData
+    );
+
+    expect(isFresh).toBe(true);
   });
 });

--- a/src/check-condition.test.ts
+++ b/src/check-condition.test.ts
@@ -1,10 +1,9 @@
-import { BigNumber, ethers } from 'ethers';
+import { ethers } from 'ethers';
 import {
   calculateUpdateInPercentage,
   checkSignedDataFreshness,
   checkUpdateCondition,
   HUNDRED_PERCENT,
-  OnChainBeaconData,
 } from './check-condition';
 import { DEFAULT_LOG_OPTIONS } from './constants';
 import { State, updateState } from './state';
@@ -60,49 +59,40 @@ describe('calculateUpdateInPercentage', () => {
 });
 
 describe('checkUpdateCondition', () => {
-  const onChainData: OnChainBeaconData = {
-    value: ethers.BigNumber.from(500),
-    timestamp: getUnixTimestamp('2019-3-21'),
-  };
+  const onChainValue = ethers.BigNumber.from(500);
 
   it('reads dapiserver value and checks the threshold condition to be true for increase', async () => {
-    const shouldUpdate = await checkUpdateCondition(onChainData, 10, ethers.BigNumber.from(560));
+    const shouldUpdate = await checkUpdateCondition(onChainValue, 10, ethers.BigNumber.from(560));
 
     expect(shouldUpdate).toEqual(true);
   });
 
   it('reads dapiserver value and checks the threshold condition to be true for decrease', async () => {
-    const shouldUpdate = await checkUpdateCondition(onChainData, 10, ethers.BigNumber.from(440));
+    const shouldUpdate = await checkUpdateCondition(onChainValue, 10, ethers.BigNumber.from(440));
 
     expect(shouldUpdate).toEqual(true);
   });
 
   it('reads dapiserver value and checks the threshold condition to be false', async () => {
-    const shouldUpdate = await checkUpdateCondition(onChainData, 10, ethers.BigNumber.from(480));
+    const shouldUpdate = await checkUpdateCondition(onChainValue, 10, ethers.BigNumber.from(480));
 
     expect(shouldUpdate).toEqual(false);
   });
 
   it('handles correctly bad JS math', async () => {
-    await expect(checkUpdateCondition(onChainData, 0.14, ethers.BigNumber.from(560))).resolves.not.toThrow();
+    await expect(checkUpdateCondition(onChainValue, 0.14, ethers.BigNumber.from(560))).resolves.not.toThrow();
   });
 });
 
 describe('checkSignedDataFreshness', () => {
   it('returns true if signed data gateway is newer then on chain record', () => {
-    const isFresh = checkSignedDataFreshness(
-      { value: BigNumber.from('123'), timestamp: getUnixTimestamp('2022-4-28') },
-      validSignedData
-    );
+    const isFresh = checkSignedDataFreshness(getUnixTimestamp('2022-4-28'), validSignedData.data.timestamp);
 
     expect(isFresh).toBe(false);
   });
 
   it('returns false if signed data gateway is older then on chain record', () => {
-    const isFresh = checkSignedDataFreshness(
-      { value: BigNumber.from('123'), timestamp: getUnixTimestamp('2019-4-28') },
-      validSignedData
-    );
+    const isFresh = checkSignedDataFreshness(getUnixTimestamp('2019-4-28'), validSignedData.data.timestamp);
 
     expect(isFresh).toBe(true);
   });

--- a/src/check-condition.ts
+++ b/src/check-condition.ts
@@ -16,6 +16,11 @@ export const calculateUpdateInPercentage = (initialValue: ethers.BigNumber, upda
   return absoluteDelta.mul(ethers.BigNumber.from(HUNDRED_PERCENT)).div(absoluteInitialValue);
 };
 
+export interface OnChainBeaconData {
+  value: ethers.BigNumber;
+  timestamp: number;
+}
+
 export const checkUpdateCondition = async (
   onChainData: OnChainBeaconData,
   deviationThreshold: number,
@@ -29,11 +34,6 @@ export const checkUpdateCondition = async (
 
   return updateInPercentage.gt(threshold);
 };
-
-export interface OnChainBeaconData {
-  value: ethers.BigNumber;
-  timestamp: number;
-}
 
 /**
  * Returns true when the signed data response is fresh enough to be used for an on chain update.

--- a/src/check-condition.ts
+++ b/src/check-condition.ts
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers';
-import { SignedData } from './validation';
 
 // Number that represents 100% is chosen to avoid overflows in DapiServer's
 // `calculateUpdateInPercentage()`. Since the reported data needs to fit
@@ -16,18 +15,12 @@ export const calculateUpdateInPercentage = (initialValue: ethers.BigNumber, upda
   return absoluteDelta.mul(ethers.BigNumber.from(HUNDRED_PERCENT)).div(absoluteInitialValue);
 };
 
-export interface OnChainBeaconData {
-  value: ethers.BigNumber;
-  timestamp: number;
-}
-
 export const checkUpdateCondition = async (
-  onChainData: OnChainBeaconData,
+  onChainVale: ethers.BigNumber,
   deviationThreshold: number,
   apiValue: ethers.BigNumber
 ): Promise<boolean> => {
-  const { value, timestamp: _timestamp } = onChainData;
-  const updateInPercentage = calculateUpdateInPercentage(value, apiValue);
+  const updateInPercentage = calculateUpdateInPercentage(onChainVale, apiValue);
   const threshold = ethers.BigNumber.from(Math.trunc(deviationThreshold * HUNDRED_PERCENT)).div(
     ethers.BigNumber.from(100)
   );
@@ -42,6 +35,6 @@ export const checkUpdateCondition = async (
  * https://github.com/api3dao/airnode-protocol-v1/blob/e0d778fabff0df888987a6db31498c93ee2f6219/contracts/dapis/DapiServer.sol#L867
  * This can happen if the gateway or Airseeker is down and Airkeeper does the updates instead.
  */
-export const checkSignedDataFreshness = (onChainData: OnChainBeaconData, signedData: SignedData) => {
-  return parseInt(signedData.data.timestamp, 10) > onChainData.timestamp;
+export const checkSignedDataFreshness = (onChainTimestamp: number, signedDataTimestamp: string) => {
+  return onChainTimestamp < parseInt(signedDataTimestamp, 10);
 };

--- a/src/check-condition.ts
+++ b/src/check-condition.ts
@@ -1,7 +1,5 @@
 import { ethers } from 'ethers';
-import { DapiServer } from '@api3/airnode-protocol-v1';
-import { go, GoAsyncOptions } from '@api3/promise-utils';
-import { logger } from './logging';
+import { SignedData } from './validation';
 
 // Number that represents 100% is chosen to avoid overflows in DapiServer's
 // `calculateUpdateInPercentage()`. Since the reported data needs to fit
@@ -19,27 +17,31 @@ export const calculateUpdateInPercentage = (initialValue: ethers.BigNumber, upda
 };
 
 export const checkUpdateCondition = async (
-  voidSigner: ethers.VoidSigner,
-  dapiServer: DapiServer,
-  beaconId: string,
+  onChainData: OnChainBeaconData,
   deviationThreshold: number,
-  apiValue: ethers.BigNumber,
-  goOptions: GoAsyncOptions
-): Promise<boolean | null> => {
-  const goDataFeed = await go(() => dapiServer.connect(voidSigner).readDataFeedWithId(beaconId), {
-    ...goOptions,
-    onAttemptError: (goError) => logger.log(`Failed attempt to read data feed. Error: ${goError.error}`),
-  });
-  if (!goDataFeed.success) {
-    logger.log(`Unable to read data feed. Error: ${goDataFeed.error}`);
-    return null;
-  }
-
-  const [dapiServerValue, _timestamp] = goDataFeed.data;
-  const updateInPercentage = calculateUpdateInPercentage(dapiServerValue, apiValue);
+  apiValue: ethers.BigNumber
+): Promise<boolean> => {
+  const { value, timestamp: _timestamp } = onChainData;
+  const updateInPercentage = calculateUpdateInPercentage(value, apiValue);
   const threshold = ethers.BigNumber.from(Math.trunc(deviationThreshold * HUNDRED_PERCENT)).div(
     ethers.BigNumber.from(100)
   );
 
   return updateInPercentage.gt(threshold);
+};
+
+export interface OnChainBeaconData {
+  value: ethers.BigNumber;
+  timestamp: number;
+}
+
+/**
+ * Returns true when the signed data response is fresh enough to be used for an on chain update.
+ *
+ * Update transaction with stale data would revert on chain, draining the sponsor wallet. See:
+ * https://github.com/api3dao/airnode-protocol-v1/blob/e0d778fabff0df888987a6db31498c93ee2f6219/contracts/dapis/DapiServer.sol#L867
+ * This can happen if the gateway or Airseeker is down and Airkeeper does the updates instead.
+ */
+export const checkSignedDataFreshness = (onChainData: OnChainBeaconData, signedData: SignedData) => {
+  return parseInt(signedData.data.timestamp, 10) > onChainData.timestamp;
 };

--- a/src/update-beacons.test.ts
+++ b/src/update-beacons.test.ts
@@ -1,0 +1,36 @@
+import { ethers } from 'ethers';
+import { logger } from './logging';
+import { readOnChainBeaconData } from './update-beacons';
+import { getUnixTimestamp } from '../test/fixtures';
+
+it('readOnChainBeaconData', async () => {
+  jest.spyOn(logger, 'log');
+  const readDataFeedWithIdMock = jest
+    .fn()
+    .mockRejectedValueOnce(new Error('cannot read chain'))
+    .mockRejectedValueOnce(new Error('some other error'))
+    .mockResolvedValue({ value: ethers.BigNumber.from('123'), timestamp: getUnixTimestamp('2019-3-21') });
+
+  const dapiServer: any = {
+    connect() {
+      return this;
+    },
+    readDataFeedWithId: readDataFeedWithIdMock,
+  };
+
+  const providerUrl = 'http://127.0.0.1:8545/';
+  const voidSigner = new ethers.VoidSigner(
+    ethers.constants.AddressZero,
+    new ethers.providers.JsonRpcProvider(providerUrl)
+  );
+
+  const onChainBeacon = await readOnChainBeaconData(voidSigner, dapiServer, 'some-id', { retries: 100_000 });
+
+  expect(onChainBeacon).toEqual({
+    data: { timestamp: 1553122800, value: ethers.BigNumber.from('123') },
+    success: true,
+  });
+  expect(logger.log).toHaveBeenCalledTimes(2);
+  expect(logger.log).toHaveBeenNthCalledWith(1, 'Failed attempt to read data feed. Error: Error: cannot read chain');
+  expect(logger.log).toHaveBeenNthCalledWith(2, 'Failed attempt to read data feed. Error: Error: some other error');
+});

--- a/src/update-beacons.test.ts
+++ b/src/update-beacons.test.ts
@@ -5,11 +5,12 @@ import { getUnixTimestamp } from '../test/fixtures';
 
 it('readOnChainBeaconData', async () => {
   jest.spyOn(logger, 'log');
+  const feedValue = { value: ethers.BigNumber.from('123'), timestamp: getUnixTimestamp('2019-3-21') };
   const readDataFeedWithIdMock = jest
     .fn()
     .mockRejectedValueOnce(new Error('cannot read chain'))
     .mockRejectedValueOnce(new Error('some other error'))
-    .mockResolvedValue({ value: ethers.BigNumber.from('123'), timestamp: getUnixTimestamp('2019-3-21') });
+    .mockResolvedValue(feedValue);
 
   const dapiServer: any = {
     connect() {
@@ -27,7 +28,7 @@ it('readOnChainBeaconData', async () => {
   const onChainBeacon = await readOnChainBeaconData(voidSigner, dapiServer, 'some-id', { retries: 100_000 });
 
   expect(onChainBeacon).toEqual({
-    data: { timestamp: 1553122800, value: ethers.BigNumber.from('123') },
+    data: feedValue,
     success: true,
   });
   expect(logger.log).toHaveBeenCalledTimes(2);

--- a/src/update-beacons.test.ts
+++ b/src/update-beacons.test.ts
@@ -25,12 +25,9 @@ it('readOnChainBeaconData', async () => {
     new ethers.providers.JsonRpcProvider(providerUrl)
   );
 
-  const onChainBeacon = await readOnChainBeaconData(voidSigner, dapiServer, 'some-id', { retries: 100_000 });
+  const onChainBeaconData = await readOnChainBeaconData(voidSigner, dapiServer, 'some-id', { retries: 100_000 });
 
-  expect(onChainBeacon).toEqual({
-    data: feedValue,
-    success: true,
-  });
+  expect(onChainBeaconData).toEqual(feedValue);
   expect(logger.log).toHaveBeenCalledTimes(2);
   expect(logger.log).toHaveBeenNthCalledWith(1, 'Failed attempt to read data feed. Error: Error: cannot read chain');
   expect(logger.log).toHaveBeenNthCalledWith(2, 'Failed attempt to read data feed. Error: Error: some other error');

--- a/test/e2e/check-condition.feature.ts
+++ b/test/e2e/check-condition.feature.ts
@@ -1,9 +1,9 @@
 import { ethers } from 'ethers';
 import * as hre from 'hardhat';
 import { DapiServer__factory as DapiServerFactory } from '@api3/airnode-protocol-v1';
-import { checkUpdateCondition, OnChainBeaconData } from '../../src/check-condition';
+import { checkUpdateCondition } from '../../src/check-condition';
 import { deployAndUpdateSubscriptions } from '../setup/deployment';
-import { readOnChainBeaconData } from '../../src/update-beacons';
+import { readOnChainBeaconData, OnChainBeaconData } from '../../src/update-beacons';
 
 // Jest version 27 has a bug where jest.setTimeout does not work correctly inside describe or test blocks
 // https://github.com/facebook/jest/issues/11607
@@ -32,12 +32,12 @@ describe('checkUpdateCondition', () => {
       ethers.utils.solidityPack(['address', 'bytes32'], [airnodeWallet.address, templateIdETH])
     );
 
-    onChainValue = await readOnChainBeaconData(voidSigner, dapiServer, beaconId, {});
+    onChainValue = (await readOnChainBeaconData(voidSigner, dapiServer, beaconId, {}))!;
   });
 
   it('returns true for increase above the deviationThreshold', async () => {
     const checkResult = await checkUpdateCondition(
-      onChainValue,
+      onChainValue.value,
       deviationThreshold,
       ethers.BigNumber.from(Math.floor(apiValue * (1 + 0.3 / 100) * _times))
     );
@@ -47,7 +47,7 @@ describe('checkUpdateCondition', () => {
 
   it('returns false for increase below the deviationThreshold', async () => {
     const checkResult = await checkUpdateCondition(
-      onChainValue,
+      onChainValue.value,
       deviationThreshold,
       ethers.BigNumber.from(Math.floor(apiValue * (1 + 0.1 / 100) * _times))
     );
@@ -57,7 +57,7 @@ describe('checkUpdateCondition', () => {
 
   it('returns true for decrease above the deviationThreshold', async () => {
     const checkResult = await checkUpdateCondition(
-      onChainValue,
+      onChainValue.value,
       deviationThreshold,
       ethers.BigNumber.from(Math.floor(apiValue * (1 - 0.3 / 100) * _times))
     );
@@ -67,7 +67,7 @@ describe('checkUpdateCondition', () => {
 
   it('returns false for decrease below the deviationThreshold', async () => {
     const checkResult = await checkUpdateCondition(
-      onChainValue,
+      onChainValue.value,
       deviationThreshold,
       ethers.BigNumber.from(Math.floor(apiValue * (1 - 0.1 / 100) * _times))
     );
@@ -77,7 +77,7 @@ describe('checkUpdateCondition', () => {
 
   it('returns false for no change', async () => {
     const checkResult = await checkUpdateCondition(
-      onChainValue,
+      onChainValue.value,
       deviationThreshold,
       ethers.BigNumber.from(apiValue * _times)
     );

--- a/test/e2e/check-condition.feature.ts
+++ b/test/e2e/check-condition.feature.ts
@@ -1,8 +1,10 @@
 import { ethers } from 'ethers';
 import * as hre from 'hardhat';
 import { DapiServer__factory as DapiServerFactory } from '@api3/airnode-protocol-v1';
-import { checkUpdateCondition } from '../../src/check-condition';
+import { assertGoSuccess } from '@api3/promise-utils';
+import { checkUpdateCondition, OnChainBeaconData } from '../../src/check-condition';
 import { deployAndUpdateSubscriptions } from '../setup/deployment';
+import { readOnChainBeaconData } from '../../src/update-beacons';
 
 // Jest version 27 has a bug where jest.setTimeout does not work correctly inside describe or test blocks
 // https://github.com/facebook/jest/issues/11607
@@ -12,11 +14,12 @@ const providerUrl = 'http://127.0.0.1:8545/';
 const provider = new ethers.providers.JsonRpcProvider(providerUrl);
 const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
 const dapiServer = DapiServerFactory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
-const goOptions = {};
 
 const apiValue = 723.39202;
 const _times = 1_000_000;
 const deviationThreshold = 0.2;
+
+let onChainValue: OnChainBeaconData;
 
 describe('checkUpdateCondition', () => {
   let beaconId: string;
@@ -29,16 +32,17 @@ describe('checkUpdateCondition', () => {
     beaconId = ethers.utils.keccak256(
       ethers.utils.solidityPack(['address', 'bytes32'], [airnodeWallet.address, templateIdETH])
     );
+
+    const goReadChain = await readOnChainBeaconData(voidSigner, dapiServer, beaconId, {});
+    assertGoSuccess(goReadChain);
+    onChainValue = goReadChain.data;
   });
 
   it('returns true for increase above the deviationThreshold', async () => {
     const checkResult = await checkUpdateCondition(
-      voidSigner,
-      dapiServer,
-      beaconId,
+      onChainValue,
       deviationThreshold,
-      ethers.BigNumber.from(Math.floor(apiValue * (1 + 0.3 / 100) * _times)),
-      goOptions
+      ethers.BigNumber.from(Math.floor(apiValue * (1 + 0.3 / 100) * _times))
     );
 
     expect(checkResult).toEqual(true);
@@ -46,12 +50,9 @@ describe('checkUpdateCondition', () => {
 
   it('returns false for increase below the deviationThreshold', async () => {
     const checkResult = await checkUpdateCondition(
-      voidSigner,
-      dapiServer,
-      beaconId,
+      onChainValue,
       deviationThreshold,
-      ethers.BigNumber.from(Math.floor(apiValue * (1 + 0.1 / 100) * _times)),
-      goOptions
+      ethers.BigNumber.from(Math.floor(apiValue * (1 + 0.1 / 100) * _times))
     );
 
     expect(checkResult).toEqual(false);
@@ -59,12 +60,9 @@ describe('checkUpdateCondition', () => {
 
   it('returns true for decrease above the deviationThreshold', async () => {
     const checkResult = await checkUpdateCondition(
-      voidSigner,
-      dapiServer,
-      beaconId,
+      onChainValue,
       deviationThreshold,
-      ethers.BigNumber.from(Math.floor(apiValue * (1 - 0.3 / 100) * _times)),
-      goOptions
+      ethers.BigNumber.from(Math.floor(apiValue * (1 - 0.3 / 100) * _times))
     );
 
     expect(checkResult).toEqual(true);
@@ -72,12 +70,9 @@ describe('checkUpdateCondition', () => {
 
   it('returns false for decrease below the deviationThreshold', async () => {
     const checkResult = await checkUpdateCondition(
-      voidSigner,
-      dapiServer,
-      beaconId,
+      onChainValue,
       deviationThreshold,
-      ethers.BigNumber.from(Math.floor(apiValue * (1 - 0.1 / 100) * _times)),
-      goOptions
+      ethers.BigNumber.from(Math.floor(apiValue * (1 - 0.1 / 100) * _times))
     );
 
     expect(checkResult).toEqual(false);
@@ -85,12 +80,9 @@ describe('checkUpdateCondition', () => {
 
   it('returns false for no change', async () => {
     const checkResult = await checkUpdateCondition(
-      voidSigner,
-      dapiServer,
-      beaconId,
+      onChainValue,
       deviationThreshold,
-      ethers.BigNumber.from(apiValue * _times),
-      goOptions
+      ethers.BigNumber.from(apiValue * _times)
     );
 
     expect(checkResult).toEqual(false);

--- a/test/e2e/check-condition.feature.ts
+++ b/test/e2e/check-condition.feature.ts
@@ -1,7 +1,6 @@
 import { ethers } from 'ethers';
 import * as hre from 'hardhat';
 import { DapiServer__factory as DapiServerFactory } from '@api3/airnode-protocol-v1';
-import { assertGoSuccess } from '@api3/promise-utils';
 import { checkUpdateCondition, OnChainBeaconData } from '../../src/check-condition';
 import { deployAndUpdateSubscriptions } from '../setup/deployment';
 import { readOnChainBeaconData } from '../../src/update-beacons';
@@ -33,9 +32,7 @@ describe('checkUpdateCondition', () => {
       ethers.utils.solidityPack(['address', 'bytes32'], [airnodeWallet.address, templateIdETH])
     );
 
-    const goReadChain = await readOnChainBeaconData(voidSigner, dapiServer, beaconId, {});
-    assertGoSuccess(goReadChain);
-    onChainValue = goReadChain.data;
+    onChainValue = await readOnChainBeaconData(voidSigner, dapiServer, beaconId, {});
   });
 
   it('returns true for increase above the deviationThreshold', async () => {

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -8,3 +8,5 @@ export const validSignedData: SignedData = {
   signature:
     '0x8aace553ec28f53cc976c8a2469d50f16de121d248495117aca36feb4950957827570e0648f82bdbc0afa6cb69dd9fe37dc7f9d58ae3aa06450e627e06c1b8031b',
 };
+
+export const getUnixTimestamp = (dateString: string) => Math.floor(Date.parse(dateString) / 1000);


### PR DESCRIPTION
https://api3dao.atlassian.net/browse/BEC-341

Please, start with reviewing `src/update-beacons.ts`. I've moved the on chain value fetching to the `updateBeacons` function and am passing it to the `checkSignedDataFreshness` (implemented now) and `checkUpdateCondition`.

The functions ensures the gateway timestamp is larger than on chain timestamp (both timestamps are UNIX timestamps).