### PR TITLE
Scripts and instructions for running Airseeker locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ re-remove the CloudFormation stack.
 2. Next step is to run this script:
 
    ```shell
-   yarn run dev:create-local-config
+   yarn run dev:setup-local-node
    ```
 
    This will deploy the DapiServer contract to the local ethereum node and also send funds to a test Airseeker sponsor

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ yarn build
 
 You need to create a configuration file `config/airseeker.json`. Take a look at `config/airseeker.example.json` for an
 example configuration file. You can use string interpolation (with `${VAR}` syntax) for providing secrets. Secrets are
-read from the environment variables. When running locally, either just with `yarn start` or via process manager, secrets
-are automatically loaded from `config/secrets.env` file. Take a look at `config/secrets.example.env` for an example
-secrets file.
+read from the environment variables. Take a look at `config/secrets.example.env` for an example secrets file.
 
 ### Gas oracle options
 
@@ -80,12 +78,6 @@ sleep 10;
 kill $pid
 ```
 
-**Invoke Airseeker (local):** (Optional)
-
-```shell
-yarn sls invoke local --config serverless.aws.yml -f airseeker
-```
-
 **Remove Airseeker:**
 
 ```shell
@@ -107,3 +99,45 @@ check the resources tab of the stack in question to see errors. Manually remove 
 
 In particular AWS will sometimes refuse to delete an associated S3 bucket. Empty the bucket and remove it, then
 re-remove the CloudFormation stack.
+
+## Running Airseeker locally (Optional)
+
+1. For running Airseeker locally you can make use of the pm2 testing services by running this command in a terminal:
+
+   ```shell
+   yarn run dev:testing-services:start
+   ```
+
+   A local ethereum node will be started along with a node.js express server that will return signed data (basically a
+   substitute to the Airnode's signed data gateway).
+
+2. Next step is to run this script:
+
+   ```shell
+   yarn run dev:create-local-config
+   ```
+
+   This will deploy the DapiServer contract to the local ethereum node and also send funds to a test Airseeker sponsor
+   wallet (used to submit data feed update transactions).
+
+3. Then you might also want to run the following script to create the required testing config files:
+
+   ```shell
+   yarn run dev:create-local-config
+   ```
+
+   You should verify that the DapiServer contract address in the `config/airseeker.json` file matches the address
+   displayed when running the script from the previous step. Secrets are automatically loaded from `config/secrets.env`
+   file when Airseeker is invoked locally.
+
+4. Lastly you need to invoke Airseeker via serverless framework like this:
+
+   ```shell
+   yarn sls invoke local --config serverless.aws.yml -f airseeker
+   ```
+
+5. If you want to stop the testing services after exiting the Airseeker process you can run the following command:
+
+   ```shell
+   yarn run dev:testing-services:stop
+   ```

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "build": "yarn clean && yarn compile",
     "clean": "rimraf -rf ./build ./dist *.tgz",
     "compile": "tsc --build tsconfig.json",
+    "dev:create-local-config": "ts-node scripts/create-local-config.js",
+    "dev:setup-local-node": "hardhat run scripts/setup-local-node.js",
     "dev:api": "ts-node test/server/server.ts",
     "dev:eth-node": "hardhat node",
     "dev:testing-services:start": "pm2 start test/testing-services.config.js",

--- a/scripts/create-local-config.js
+++ b/scripts/create-local-config.js
@@ -1,0 +1,126 @@
+const fs = require('fs');
+const path = require('path');
+
+const buildAirseekerConfig = () => ({
+  airseekerWalletMnemonic: '${AIRSEEKER_WALLET_MNEMONIC}',
+  log: {
+    format: 'plain',
+    level: 'DEBUG',
+  },
+  beacons: {
+    '0x924b5d4cb3ec6366ae4302a1ca6aec035594ea3ea48a102d160b50b0c43ebfb5': {
+      airnode: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+      templateId: '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa',
+      fetchInterval: 45,
+    },
+    '0xbf7ce55d109fd196de2a8bf1515d166c56c9decbe9cb473656bbca30d5743990': {
+      airnode: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+      templateId: '0x0bbf5f2ec4b0e9faf5b89b4ddbed9bdad7a542cc258ffd7b106b523aeae039a6',
+      fetchInterval: 45,
+    },
+  },
+  beaconSets: {
+    '0xf7f1620b7f422eb9a69c8e21b317ba1555d3d87e1d804f0b024f03b107e411e8': [
+      '0x924b5d4cb3ec6366ae4302a1ca6aec035594ea3ea48a102d160b50b0c43ebfb5',
+      '0xbf7ce55d109fd196de2a8bf1515d166c56c9decbe9cb473656bbca30d5743990',
+    ],
+  },
+  chains: {
+    31337: {
+      contracts: {
+        DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+      },
+      providers: {
+        local: {
+          url: '${CP_LOCAL_URL}',
+        },
+      },
+      options: {
+        txType: 'legacy',
+        fulfillmentGasLimit: 500_000,
+        gasOracle: {
+          maxTimeout: 1, // Set low to make tests run faster
+          fallbackGasPrice: {
+            value: 10,
+            unit: 'gwei',
+          },
+          recommendedGasPriceMultiplier: 1,
+          latestGasPriceOptions: {
+            percentile: 60,
+            minTransactionCount: 9,
+            pastToCompareInBlocks: 20,
+            maxDeviationMultiplier: 5, // Set high to ensure that txs do not use fallback
+          },
+        },
+      },
+    },
+  },
+  gateways: {
+    '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace': [
+      {
+        apiKey: '${HTTP_GATEWAY_API_KEY}',
+        url: '${HTTP_SIGNED_DATA_GATEWAY_URL}',
+      },
+    ],
+  },
+  templates: {
+    '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa': {
+      endpointId: '0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6',
+      parameters:
+        '0x3173737373730000000000000000000000000000000000000000000000000000746f00000000000000000000000000000000000000000000000000000000000055534400000000000000000000000000000000000000000000000000000000005f74797065000000000000000000000000000000000000000000000000000000696e7432353600000000000000000000000000000000000000000000000000005f70617468000000000000000000000000000000000000000000000000000000726573756c7400000000000000000000000000000000000000000000000000005f74696d65730000000000000000000000000000000000000000000000000000313030303030300000000000000000000000000000000000000000000000000066726f6d000000000000000000000000000000000000000000000000000000004554480000000000000000000000000000000000000000000000000000000000',
+    },
+    '0x0bbf5f2ec4b0e9faf5b89b4ddbed9bdad7a542cc258ffd7b106b523aeae039a6': {
+      endpointId: '0x13dea3311fe0d6b84f4daeab831befbc49e19e6494c41e9e065a09c3c68f43b6',
+      parameters:
+        '0x3173737373730000000000000000000000000000000000000000000000000000746f00000000000000000000000000000000000000000000000000000000000055534400000000000000000000000000000000000000000000000000000000005f74797065000000000000000000000000000000000000000000000000000000696e7432353600000000000000000000000000000000000000000000000000005f70617468000000000000000000000000000000000000000000000000000000726573756c7400000000000000000000000000000000000000000000000000005f74696d65730000000000000000000000000000000000000000000000000000313030303030300000000000000000000000000000000000000000000000000066726f6d000000000000000000000000000000000000000000000000000000004254430000000000000000000000000000000000000000000000000000000000',
+    },
+  },
+  triggers: {
+    dataFeedUpdates: {
+      31337: {
+        '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC': {
+          beacons: [
+            {
+              beaconId: '0x924b5d4cb3ec6366ae4302a1ca6aec035594ea3ea48a102d160b50b0c43ebfb5',
+              deviationThreshold: 0.2,
+              heartbeatInterval: 86400,
+            },
+            {
+              beaconId: '0xbf7ce55d109fd196de2a8bf1515d166c56c9decbe9cb473656bbca30d5743990',
+              deviationThreshold: 0.2,
+              heartbeatInterval: 86400,
+            },
+          ],
+          beaconSets: [
+            {
+              beaconSetId: '0xf7f1620b7f422eb9a69c8e21b317ba1555d3d87e1d804f0b024f03b107e411e8',
+              deviationThreshold: 0.01,
+              heartbeatInterval: 86400,
+            },
+          ],
+          updateInterval: 50,
+        },
+      },
+    },
+  },
+});
+
+const buildLocalSecrets = () =>
+  "AIRSEEKER_WALLET_MNEMONIC: 'achieve climb couple wait accident symbol spy blouse reduce foil echo label' \
+  \nCP_LOCAL_URL: 'http://127.0.0.1:8545/' \
+  \nHTTP_GATEWAY_API_KEY: 'some-api-key' \
+  \nHTTP_SIGNED_DATA_GATEWAY_URL: 'http://localhost:5432/signed-data-gateway/'";
+
+async function main() {
+  const airseekerConfig = buildAirseekerConfig();
+  fs.writeFileSync(path.join(__dirname, '..', 'config', 'airseeker.json'), JSON.stringify(airseekerConfig, null, 2));
+  const airseekerSecrets = buildLocalSecrets();
+  fs.writeFileSync(path.join(__dirname, '..', 'config', 'secrets.env'), airseekerSecrets);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/setup-local-node.js
+++ b/scripts/setup-local-node.js
@@ -1,0 +1,63 @@
+require('@nomiclabs/hardhat-ethers');
+const hre = require('hardhat');
+const node = require('@api3/airnode-node');
+const {
+  AccessControlRegistry__factory: AccessControlRegistryFactory,
+  AirnodeProtocol__factory: AirnodeProtocolFactory,
+  DapiServer__factory: DapiServerFactory,
+} = require('@api3/airnode-protocol-v1');
+const { PROTOCOL_ID } = require('../src/constants');
+
+async function main() {
+  const [deployer, manager, sponsor] = await hre.ethers.getSigners();
+
+  const dapiServerAdminRoleDescription = 'DapiServer admin';
+
+  // Deploy contracts
+  const accessControlRegistryFactory = new hre.ethers.ContractFactory(
+    AccessControlRegistryFactory.abi,
+    AccessControlRegistryFactory.bytecode,
+    deployer
+  );
+  const accessControlRegistry = await accessControlRegistryFactory.connect(deployer).deploy();
+
+  const airnodeProtocolFactory = new hre.ethers.ContractFactory(
+    AirnodeProtocolFactory.abi,
+    AirnodeProtocolFactory.bytecode,
+    deployer
+  );
+  const airnodeProtocol = await airnodeProtocolFactory.connect(deployer).deploy();
+
+  const dapiServerFactory = new hre.ethers.ContractFactory(DapiServerFactory.abi, DapiServerFactory.bytecode, deployer);
+  const dapiServer = await dapiServerFactory
+    .connect(deployer)
+    .deploy(accessControlRegistry.address, dapiServerAdminRoleDescription, manager.address, airnodeProtocol.address);
+
+  console.log('🚀 DapiServer address:', dapiServer.address);
+
+  // Access control
+  const managerRootRole = await accessControlRegistry.deriveRootRole(manager.address);
+  await accessControlRegistry
+    .connect(manager)
+    .initializeRoleAndGrantToSender(managerRootRole, dapiServerAdminRoleDescription);
+
+  const airseekerSponsorWallet = node.evm.deriveSponsorWalletFromMnemonic(
+    'achieve climb couple wait accident symbol spy blouse reduce foil echo label',
+    sponsor.address,
+    PROTOCOL_ID
+  );
+
+  await deployer.sendTransaction({
+    to: airseekerSponsorWallet.address,
+    value: hre.ethers.utils.parseEther('1'),
+  });
+
+  console.log('🚀 Sent 1 ETH to Airseeker sponsor wallet', airseekerSponsorWallet.address);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Closes #170 

This a very basic and simple setup that will let devs run Airseeker locally by following a few steps in a matter of seconds. This will be useful when trying to test new implementations or bug fixes. 

When Airnode v0.8 package is published we can make this setup more customizable and improve the scripts to maybe allow user inputs to help create a dynamic config file. The idea is to make a better use of the local signed data gateway that was implemented in that version of Airnode.