### PR TITLE
Adds workaround to support fetching signed data from http gateways wi…

### DIFF
--- a/src/make-request.test.ts
+++ b/src/make-request.test.ts
@@ -100,6 +100,70 @@ describe('makeSignedDataGatewayRequests', () => {
     );
   });
 
+  it('makes requests and resolves even for legacy responses', async () => {
+    const mockedAxios = (axios as any as jest.Mock)
+      .mockImplementationOnce(() => {
+        throw new Error('timeout error');
+      })
+      .mockReturnValueOnce({
+        data: {
+          timestamp: 'invalid',
+          encodedValue: '0x000000000000000000000000000000000000000000000000000000000invalid',
+          signature: 'invalid signature',
+        },
+      })
+      .mockReturnValueOnce({
+        data: {
+          data: { timestamp: validSignedData.timestamp, value: validSignedData.encodedValue },
+          signature: validSignedData.signature,
+        },
+      });
+    jest.spyOn(logger, 'info');
+    jest.spyOn(logger, 'warn');
+
+    const response = await makeSignedDataGatewayRequests(
+      [
+        { apiKey: 'api-key-1', url: 'https://gateway-1.com/' },
+        { apiKey: 'api-key-2', url: 'https://gateway-2.com/' },
+        { apiKey: 'api-key-3', url: 'https://gateway-3.com/' },
+      ],
+      { parameters: '0x123456789', endpointId: 'endpoint', id: templateId }
+    );
+
+    expect(response).toEqual(validSignedData);
+    expect(mockedAxios).toHaveBeenCalledTimes(3);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to make signed data gateway request for gateway: "https://gateway-1.com/endpoint". Error: "Error: timeout error"',
+      { meta: { 'Template-ID': templateId } }
+    );
+    const zodErrors = [
+      {
+        validation: 'regex',
+        code: 'invalid_string',
+        message: 'Invalid',
+        path: ['encodedValue'],
+      },
+      {
+        validation: 'regex',
+        code: 'invalid_string',
+        message: 'Invalid',
+        path: ['signature'],
+      },
+    ];
+    expect(logger.warn).toHaveBeenCalledWith(
+      `Failed to parse signed data response for gateway: "https://gateway-2.com/endpoint". Error: "${JSON.stringify(
+        zodErrors,
+        null,
+        2
+      )}"`,
+      { meta: { 'Template-ID': templateId } }
+    );
+    expect(logger.info).toBeCalledWith(
+      `Using the following signed data response: "${JSON.stringify(validSignedData)}"`,
+      { meta: { 'Template-ID': templateId } }
+    );
+  });
+
   it('handles a case when all gateways error out', async () => {
     const mockedAxios = (axios as any as jest.Mock)
       .mockImplementationOnce(() => {

--- a/src/update-data-feeds.ts
+++ b/src/update-data-feeds.ts
@@ -317,7 +317,7 @@ export const updateBeaconSets = async (providerSponsorBeacons: ProviderSponsorDa
     provider,
   } = initialUpdateData;
   const { chainId } = provider;
-  // Process beacon updates
+  // Process beacon set updates
   let nonce = transactionCount;
 
   for (const beaconSet of beaconSets) {
@@ -434,7 +434,7 @@ export const updateBeaconSets = async (providerSponsorBeacons: ProviderSponsorDa
       );
       if (shouldUpdate === null) {
         logger.warn(`Unable to fetch current beacon set value`, logOptionsBeaconSetId);
-        // This can happen only if we reach the total timeout so it makes no sense to continue with the rest of the beacons
+        // This can happen only if we reach the total timeout so it makes no sense to continue with the rest of the beaconSets
         return;
       }
       if (!shouldUpdate) {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -243,6 +243,10 @@ export const configSchema = z
   .superRefine(validateDataFeedUpdatesReferences);
 export const encodedValueSchema = z.string().regex(/^0x[a-fA-F0-9]{64}$/);
 export const signatureSchema = z.string().regex(/^0x[a-fA-F0-9]{130}$/);
+export const signedDataSchemaLegacy = z.object({
+  data: z.object({ timestamp: z.string(), value: encodedValueSchema }),
+  signature: signatureSchema,
+});
 export const signedDataSchema = z.object({
   timestamp: z.string(),
   encodedValue: encodedValueSchema,


### PR DESCRIPTION
…th version older than v0.8.0

Required for being able to deploy a new version of Airseeker that expects v0.8.0 Airnode packages but uses older deployed Airnodes
https://github.com/api3dao/operations/issues/159