### PR TITLE
Enable building the project with production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "lodash": "^4.17.21",
     "promise.any": "^2.0.4",
     "source-map-support": "^0.5.21",
+    "serverless": "^3.23.0",
+    "typescript": "^4.8.4",
     "zod": "^3.17.3"
   },
   "devDependencies": {
@@ -75,9 +77,7 @@
     "pm2": "^5.2.2",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
-    "serverless": "^3.23.0",
     "ts-jest": "^28.0.8",
-    "ts-node": "^10.9.1",
-    "typescript": "^4.8.4"
+    "ts-node": "^10.9.1"
   }
 }


### PR DESCRIPTION
Required for deployment with operations-database airseeker deployer lambda where it uses `npm install --production --ignore-scripts`