### PR TITLE
Release Airseeker v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api3/airseeker",
   "license": "MIT",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A tool to update beacons with signed responses from remote Airnode gateways",
   "main": "./dist/index.js",
   "types": "./dist/validation",


### PR DESCRIPTION
A small PR to confirm the changes required to release a new version of Airseeker.

Below are the expected release notes (for Github):
## Highlights
* Drop fetching blockNumber by @bdrhn9 in https://github.com/api3dao/airseeker/pull/253
* Change execution order of beacon update to reduce RPC calls by @bdrhn9 in https://github.com/api3dao/airseeker/pull/276
* Allow for direct gateway calls and inclusion of associated resources in `airseeker.json` by @bdrhn9 in https://github.com/api3dao/airseeker/pull/257

## Breaking Changes
* Bump @api3/airnode-validator from 0.8.0 to 0.9.0 by @dependabot in https://github.com/api3dao/airseeker/pull/266
    * This requires various changes related to the validation schema. For more information refer to the upstream package documentation.
* Allow for direct gateway calls and inclusion of associated resources in `airseeker.json` by @bdrhn9 in https://github.com/api3dao/airseeker/pull/257
    * This change requires additional configuration fields in `airseeker.json` 

## What's Changed
* Airseeker 220922-1310 deployment by @acenolaza in https://github.com/api3dao/airseeker/pull/248
* Bump eslint from 8.22.0 to 8.24.0 by @dependabot in https://github.com/api3dao/airseeker/pull/249
* Bump @types/lodash from 4.14.184 to 4.14.185 by @dependabot in https://github.com/api3dao/airseeker/pull/239
* Bump vm2 from 3.9.9 to 3.9.11 by @dependabot in https://github.com/api3dao/airseeker/pull/252
* Bump @typescript-eslint/eslint-plugin from 5.33.0 to 5.38.1 by @dependabot in https://github.com/api3dao/airseeker/pull/255
* Bump eslint-plugin-jest from 26.8.3 to 27.0.4 by @dependabot in https://github.com/api3dao/airseeker/pull/231
* Bump @types/lodash from 4.14.185 to 4.14.186 by @dependabot in https://github.com/api3dao/airseeker/pull/262
* Bump @types/node from 18.7.4 to 18.8.3 by @dependabot in https://github.com/api3dao/airseeker/pull/267
* Bump ethers from 5.7.0 to 5.7.1 by @dependabot in https://github.com/api3dao/airseeker/pull/259
* Bump eslint from 8.24.0 to 8.25.0 by @dependabot in https://github.com/api3dao/airseeker/pull/268
* Allow Airseeker to make direct API call by @bdrhn9 in https://github.com/api3dao/airseeker/pull/257
* Bump serverless from 3.21.0 to 3.23.0 by @dependabot in https://github.com/api3dao/airseeker/pull/274
* Bump @typescript-eslint/parser from 5.33.0 to 5.40.0 by @dependabot in https://github.com/api3dao/airseeker/pull/273
* Bump @api3/airnode-validator from 0.8.0 to 0.9.0 by @dependabot in https://github.com/api3dao/airseeker/pull/266
* Bump hardhat from 2.10.1 to 2.12.0 by @dependabot in https://github.com/api3dao/airseeker/pull/278
* Bump pm2 from 5.2.0 to 5.2.2 by @dependabot in https://github.com/api3dao/airseeker/pull/279
* Bump eslint-plugin-jest from 27.0.4 to 27.1.1 by @dependabot in https://github.com/api3dao/airseeker/pull/277
* Bump @types/node from 18.8.3 to 18.8.5 by @dependabot in https://github.com/api3dao/airseeker/pull/281
* Bump typescript from 4.7.4 to 4.8.4 by @dependabot in https://github.com/api3dao/airseeker/pull/282
* Bump @nomiclabs/hardhat-ethers from 2.1.0 to 2.2.0 by @dependabot in https://github.com/api3dao/airseeker/pull/271
* Bump @typescript-eslint/eslint-plugin from 5.38.1 to 5.40.0 by @dependabot in https://github.com/api3dao/airseeker/pull/285
* Bump @types/node from 18.8.5 to 18.11.0 by @dependabot in https://github.com/api3dao/airseeker/pull/290
* Change execution order of beacon update to reduce RPC calls by @bdrhn9 in https://github.com/api3dao/airseeker/pull/276
* Bump axios from 0.27.2 to 1.1.3 by @dependabot in https://github.com/api3dao/airseeker/pull/289
* Bump @api3/airnode-protocol-v1 from 0.7.0 to 0.8.0 by @dependabot in https://github.com/api3dao/airseeker/pull/288
* Bump eslint-plugin-jest from 27.1.1 to 27.1.2 by @dependabot in https://github.com/api3dao/airseeker/pull/287
* Bump @typescript-eslint/eslint-plugin from 5.40.0 to 5.40.1 by @dependabot in https://github.com/api3dao/airseeker/pull/295
* Bump ethers from 5.7.1 to 5.7.2 by @dependabot in https://github.com/api3dao/airseeker/pull/292
* Allow creation of airseeker configuration  by @Ashar2shahid in https://github.com/api3dao/airseeker/pull/264
* Bump @types/node from 18.11.0 to 18.11.5 by @dependabot in https://github.com/api3dao/airseeker/pull/296
* Bump eslint-plugin-jest from 27.1.2 to 27.1.3 by @dependabot in https://github.com/api3dao/airseeker/pull/293
* Bump eslint-plugin-functional from 4.2.2 to 4.4.1 by @dependabot in https://github.com/api3dao/airseeker/pull/280

## New Contributors
* @bdrhn9 made their first contribution in https://github.com/api3dao/airseeker/pull/253

**Full Changelog**: https://github.com/api3dao/airseeker/compare/v0.4.0...v0.5.0