### PR TITLE
Tighten update conditions according to changes in the Api3ServerV1

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ re-remove the CloudFormation stack.
    yarn run dev:setup-local-node
    ```
 
-   This will deploy the DapiServer contract to the local ethereum node and also send funds to a test Airseeker sponsor
+   This will deploy the Api3ServerV1 contract to the local ethereum node and also send funds to a test Airseeker sponsor
    wallet (used to submit data feed update transactions).
 
 3. Then you might also want to run the following script to create the required testing config files:
@@ -107,7 +107,7 @@ re-remove the CloudFormation stack.
    yarn run dev:create-local-config
    ```
 
-   You should verify that the DapiServer contract address in the `config/airseeker.json` file matches the address
+   You should verify that the Api3ServerV1 contract address in the `config/airseeker.json` file matches the address
    displayed when running the script from the previous step. Secrets are automatically loaded from `config/secrets.env`
    file when Airseeker is invoked locally.
 

--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -33,7 +33,7 @@
   "chains": {
     "1": {
       "contracts": {
-        "Api3ServerV1": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+        "Api3ServerV1": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
       },
       "providers": {
         "selfHostedMainnet": {
@@ -69,7 +69,7 @@
     },
     "3": {
       "contracts": {
-        "Api3ServerV1": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+        "Api3ServerV1": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
       },
       "providers": {
         "infuraRopsten": {

--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -33,7 +33,7 @@
   "chains": {
     "1": {
       "contracts": {
-        "DapiServer": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+        "Api3ServerV1": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
       },
       "providers": {
         "selfHostedMainnet": {
@@ -69,7 +69,7 @@
     },
     "3": {
       "contracts": {
-        "DapiServer": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+        "Api3ServerV1": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
       },
       "providers": {
         "infuraRopsten": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@api3/airnode-abi": "^0.8.0",
     "@api3/airnode-node": "^0.8.0",
     "@api3/airnode-protocol": "^0.9.2",
-    "@api3/airnode-protocol-v1": "1.1.2",
+    "@api3/airnode-protocol-v1": "1.2.4",
     "@api3/airnode-utilities": "^0.8.0",
     "@api3/airnode-validator": "^0.9.0",
     "@api3/promise-utils": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@api3/airnode-abi": "^0.8.0",
     "@api3/airnode-node": "^0.8.0",
     "@api3/airnode-protocol": "^0.9.2",
-    "@api3/airnode-protocol-v1": "^1.0.0-alpha.0",
+    "@api3/airnode-protocol-v1": "1.1.2",
     "@api3/airnode-utilities": "^0.8.0",
     "@api3/airnode-validator": "^0.9.0",
     "@api3/promise-utils": "^0.3.0",

--- a/scripts/create-local-config.js
+++ b/scripts/create-local-config.js
@@ -28,7 +28,7 @@ const buildAirseekerConfig = () => ({
   chains: {
     31337: {
       contracts: {
-        DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
       },
       providers: {
         local: {

--- a/scripts/create-local-config.js
+++ b/scripts/create-local-config.js
@@ -28,7 +28,7 @@ const buildAirseekerConfig = () => ({
   chains: {
     31337: {
       contracts: {
-        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
       },
       providers: {
         local: {

--- a/scripts/setup-local-node.js
+++ b/scripts/setup-local-node.js
@@ -5,7 +5,7 @@ const protocol = require('@api3/airnode-protocol');
 const {
   AccessControlRegistry__factory: AccessControlRegistryFactory,
   AirnodeProtocol__factory: AirnodeProtocolFactory,
-  DapiServer__factory: DapiServerFactory,
+  Api3ServerV1__factory: Api3ServerV1Factory,
 } = require('@api3/airnode-protocol-v1');
 
 async function main() {
@@ -28,10 +28,14 @@ async function main() {
   );
   const airnodeProtocol = await airnodeProtocolFactory.connect(deployer).deploy();
 
-  const dapiServerFactory = new hre.ethers.ContractFactory(DapiServerFactory.abi, DapiServerFactory.bytecode, deployer);
+  const dapiServerFactory = new hre.ethers.ContractFactory(
+    Api3ServerV1Factory.abi,
+    Api3ServerV1Factory.bytecode,
+    deployer
+  );
   const dapiServer = await dapiServerFactory
     .connect(deployer)
-    .deploy(accessControlRegistry.address, dapiServerAdminRoleDescription, manager.address, airnodeProtocol.address);
+    .deploy(accessControlRegistry.address, dapiServerAdminRoleDescription, manager.address);
 
   console.log('🚀 DapiServer address:', dapiServer.address);
 

--- a/scripts/setup-local-node.js
+++ b/scripts/setup-local-node.js
@@ -4,14 +4,13 @@ const node = require('@api3/airnode-node');
 const protocol = require('@api3/airnode-protocol');
 const {
   AccessControlRegistry__factory: AccessControlRegistryFactory,
-  AirnodeProtocol__factory: AirnodeProtocolFactory,
   Api3ServerV1__factory: Api3ServerV1Factory,
 } = require('@api3/airnode-protocol-v1');
 
 async function main() {
   const [deployer, manager, sponsor] = await hre.ethers.getSigners();
 
-  const dapiServerAdminRoleDescription = 'DapiServer admin';
+  const api3ServerV1AdminRoleDescription = 'Api3ServerV1 admin';
 
   // Deploy contracts
   const accessControlRegistryFactory = new hre.ethers.ContractFactory(
@@ -21,29 +20,22 @@ async function main() {
   );
   const accessControlRegistry = await accessControlRegistryFactory.connect(deployer).deploy();
 
-  const airnodeProtocolFactory = new hre.ethers.ContractFactory(
-    AirnodeProtocolFactory.abi,
-    AirnodeProtocolFactory.bytecode,
-    deployer
-  );
-  const airnodeProtocol = await airnodeProtocolFactory.connect(deployer).deploy();
-
-  const dapiServerFactory = new hre.ethers.ContractFactory(
+  const api3ServerV1Factory = new hre.ethers.ContractFactory(
     Api3ServerV1Factory.abi,
     Api3ServerV1Factory.bytecode,
     deployer
   );
-  const dapiServer = await dapiServerFactory
+  const api3ServerV1 = await api3ServerV1Factory
     .connect(deployer)
-    .deploy(accessControlRegistry.address, dapiServerAdminRoleDescription, manager.address);
+    .deploy(accessControlRegistry.address, api3ServerV1AdminRoleDescription, manager.address);
 
-  console.log('🚀 DapiServer address:', dapiServer.address);
+  console.log('🚀 Api3ServerV1 address:', api3ServerV1.address);
 
   // Access control
   const managerRootRole = hre.ethers.utils.solidityKeccak256(['address'], [manager.address]);
   await accessControlRegistry
     .connect(manager)
-    .initializeRoleAndGrantToSender(managerRootRole, dapiServerAdminRoleDescription);
+    .initializeRoleAndGrantToSender(managerRootRole, api3ServerV1AdminRoleDescription);
 
   const airseekerSponsorWallet = node.evm.deriveSponsorWalletFromMnemonic(
     'achieve climb couple wait accident symbol spy blouse reduce foil echo label',

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,7 +1,5 @@
 import { writeFileSync } from 'fs';
-import * as protocol from '@api3/airnode-protocol-v1';
 import { format } from 'prettier';
-import { ethers } from 'ethers';
 
 const PRETTIER_CONFIG = {
   bracketSpacing: true,
@@ -61,16 +59,4 @@ export const sanitiseFilename = (filename: string) => {
     .replace(reservedRe, '_')
     .replace(windowsReservedRe, '_')
     .toLowerCase();
-};
-
-export const getDapiServerInterface = () => {
-  return new ethers.utils.Interface(protocol.Api3ServerV1__factory.abi);
-};
-
-export const getDapiServerContract = (dapiServerAddress: string, provider: ethers.providers.JsonRpcProvider) => {
-  return new ethers.Contract(dapiServerAddress, protocol.Api3ServerV1__factory.abi, provider);
-};
-
-export const getDapiNameHash = (dapiName: any) => {
-  return ethers.utils.solidityKeccak256(['bytes32'], [ethers.utils.formatBytes32String(dapiName)]);
 };

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -64,11 +64,11 @@ export const sanitiseFilename = (filename: string) => {
 };
 
 export const getDapiServerInterface = () => {
-  return new ethers.utils.Interface(protocol.DapiServer__factory.abi);
+  return new ethers.utils.Interface(protocol.Api3ServerV1__factory.abi);
 };
 
 export const getDapiServerContract = (dapiServerAddress: string, provider: ethers.providers.JsonRpcProvider) => {
-  return new ethers.Contract(dapiServerAddress, protocol.DapiServer__factory.abi, provider);
+  return new ethers.Contract(dapiServerAddress, protocol.Api3ServerV1__factory.abi, provider);
 };
 
 export const getDapiNameHash = (dapiName: any) => {

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -21,6 +21,7 @@ export const calculateMedian = (arr: ethers.BigNumber[]) => {
   return arr.length % 2 !== 0 ? nums[mid] : nums[mid - 1].add(nums[mid]).div(2);
 };
 
+// TODO: check Api3ServerV1 to determine if this is still correct
 // Calculate beacon set timestamp from beacon timestamps (https://github.com/api3dao/airnode-protocol-v1/blob/main/contracts/dapis/DapiServer.sol#L443)
 export const calculateBeaconSetTimestamp = (beaconSetBeaconTimestamps: string[]) => {
   const accumulatedTimestamp = beaconSetBeaconTimestamps.reduce((total, next) => total + parseInt(next, 10), 0);

--- a/src/check-condition.test.ts
+++ b/src/check-condition.test.ts
@@ -1,10 +1,5 @@
 import { ethers } from 'ethers';
-import {
-  checkFulfillmentDataTimestamp,
-  checkFulfillmentDataValue,
-  checkOnchainDataFreshness,
-  checkUpdateCondition,
-} from './check-condition';
+import { checkFulfillmentDataTimestamp, checkOnchainDataFreshness, checkUpdateCondition } from './check-condition';
 import { getUnixTimestamp } from '../test/fixtures';
 
 describe('checkUpdateCondition', () => {
@@ -51,37 +46,6 @@ describe('checkFulfillmentDataTimestamp', () => {
 
   it('returns false if fulfillment data has same timestamp with on-chain record', () => {
     const isFresh = checkFulfillmentDataTimestamp(onChainData.timestamp, onChainData.timestamp);
-    expect(isFresh).toBe(false);
-  });
-});
-
-describe('checkFulfillmentDataValue', () => {
-  const onChainData = {
-    value: ethers.BigNumber.from(10),
-    timestamp: getUnixTimestamp('2019-4-28'),
-  };
-  const fulfillmentDataValue = ethers.BigNumber.from(20);
-
-  // this is not a possible case however better to check
-  it("returns true if on chain record hasn't been initialized while both values are same", () => {
-    const uninitializedOnChainData = { ...onChainData, timestamp: 0 };
-    const isFresh = checkFulfillmentDataValue(uninitializedOnChainData, uninitializedOnChainData.value);
-    expect(isFresh).toBe(true);
-  });
-
-  it("returns true if on chain record hasn't been initialized while both values are different", () => {
-    const uninitializedOnChainData = { ...onChainData, timestamp: 0 };
-    const isFresh = checkFulfillmentDataValue(uninitializedOnChainData, fulfillmentDataValue);
-    expect(isFresh).toBe(true);
-  });
-
-  it('returns true if fulfillment data is different than on chain record', () => {
-    const isFresh = checkFulfillmentDataValue(onChainData, fulfillmentDataValue);
-    expect(isFresh).toBe(true);
-  });
-
-  it('returns false if fulfillment data is same with on chain record', () => {
-    const isFresh = checkFulfillmentDataValue(onChainData, onChainData.value);
     expect(isFresh).toBe(false);
   });
 });

--- a/src/check-condition.test.ts
+++ b/src/check-condition.test.ts
@@ -10,19 +10,19 @@ import { getUnixTimestamp } from '../test/fixtures';
 describe('checkUpdateCondition', () => {
   const onChainValue = ethers.BigNumber.from(500);
 
-  it('reads dapiserver value and checks the threshold condition to be true for increase', () => {
+  it('returns true when api value is higher and deviation threshold is reached', () => {
     const shouldUpdate = checkUpdateCondition(onChainValue, 10, ethers.BigNumber.from(560));
 
     expect(shouldUpdate).toEqual(true);
   });
 
-  it('reads dapiserver value and checks the threshold condition to be true for decrease', () => {
+  it('returns true when api value is lower and deviation threshold is reached', () => {
     const shouldUpdate = checkUpdateCondition(onChainValue, 10, ethers.BigNumber.from(440));
 
     expect(shouldUpdate).toEqual(true);
   });
 
-  it('reads dapiserver value and checks the threshold condition to be false', () => {
+  it('returns false when deviation threshold is not reached', () => {
     const shouldUpdate = checkUpdateCondition(onChainValue, 10, ethers.BigNumber.from(480));
 
     expect(shouldUpdate).toEqual(false);

--- a/src/check-condition.ts
+++ b/src/check-condition.ts
@@ -2,11 +2,6 @@ import { ethers } from 'ethers';
 import { calculateUpdateInPercentage } from './calculations';
 import { HUNDRED_PERCENT } from './constants';
 
-type OnChainData = {
-  value: ethers.BigNumber;
-  timestamp: number;
-};
-
 export const checkUpdateCondition = (
   onChainValue: ethers.BigNumber,
   deviationThreshold: number,
@@ -29,21 +24,6 @@ export const checkUpdateCondition = (
  */
 export const checkFulfillmentDataTimestamp = (onChainDataTimestamp: number, fulfillmentDataTimestamp: number) => {
   return onChainDataTimestamp < fulfillmentDataTimestamp;
-};
-
-/**
- * Returns true when the on chain data isn't initialized or the fulfillment data value is different than
- * on chain data value.
- *
- * Update transaction with stale data would revert on chain, draining the sponsor wallet. See:
- * https://github.com/api3dao/airnode-protocol-v1/blob/dev/contracts/dapis/DataFeedServer.sol#L122
- * This can happen if the gateway or Airseeker is down and Airkeeper does the updates instead.
- */
-export const checkFulfillmentDataValue = (onChainData: OnChainData, fulfillmentDataValue: ethers.BigNumber) => {
-  if (onChainData.timestamp !== 0) {
-    return onChainData.value !== fulfillmentDataValue;
-  }
-  return true;
 };
 
 /**

--- a/src/fetch-beacon-data.test.ts
+++ b/src/fetch-beacon-data.test.ts
@@ -51,7 +51,7 @@ const config: Config = {
   chains: {
     '1': {
       contracts: {
-        DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
       },
       providers: {
         selfHostedMainnet: {
@@ -87,7 +87,7 @@ const config: Config = {
     },
     '3': {
       contracts: {
-        DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
       },
       providers: {
         infuraRopsten: {

--- a/src/fetch-beacon-data.test.ts
+++ b/src/fetch-beacon-data.test.ts
@@ -51,7 +51,7 @@ const config: Config = {
   chains: {
     '1': {
       contracts: {
-        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
       },
       providers: {
         selfHostedMainnet: {
@@ -87,7 +87,7 @@ const config: Config = {
     },
     '3': {
       contracts: {
-        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
       },
       providers: {
         infuraRopsten: {

--- a/src/update-data-feeds.test.ts
+++ b/src/update-data-feeds.test.ts
@@ -58,7 +58,7 @@ const config: Config = {
   chains: {
     '1': {
       contracts: {
-        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
       },
       providers: {
         selfHostedMainnet: {
@@ -94,7 +94,7 @@ const config: Config = {
     },
     '3': {
       contracts: {
-        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
       },
       providers: {
         infuraRopsten: {
@@ -437,7 +437,7 @@ describe('initializeUpdateCycle', () => {
       provider,
     } = initialUpdateData!;
 
-    expect(contract.address).toEqual('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0');
+    expect(contract.address).toEqual('0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512');
     expect(sponsorWallet.address).toEqual('0x1129eEDf4996cF133e0e9555d4c9d305c9918EC5');
     expect(voidSigner.address).toEqual(ethers.constants.AddressZero);
     expect(totalTimeout).toEqual(1_000);

--- a/src/update-data-feeds.test.ts
+++ b/src/update-data-feeds.test.ts
@@ -1,4 +1,4 @@
-import { DapiServer__factory as DapiServerFactory } from '@api3/airnode-protocol-v1';
+import { Api3ServerV1__factory as Api3ServerV1Factory } from '@api3/airnode-protocol-v1';
 import { ethers } from 'ethers';
 import * as state from './state';
 import * as api from './update-data-feeds';
@@ -297,7 +297,7 @@ describe('updateDataFeedsInLoop', () => {
 });
 
 describe('updateBeaconSets', () => {
-  it('calls updateDataFeedWithSignedData in DapiServer contract', async () => {
+  it('calls updateBeaconSetWithBeacons in DapiServer contract', async () => {
     state.updateState((currentState) => ({
       ...currentState,
       beaconValues: {
@@ -321,17 +321,17 @@ describe('updateBeaconSets', () => {
         })
       );
 
-    const updateDataFeedWithSignedDataSpy = jest.fn();
-    const updateDataFeedWithSignedDataMock = updateDataFeedWithSignedDataSpy.mockImplementation(async () => ({
+    const updateBeaconSetWithBeaconsSpy = jest.fn();
+    const updateBeaconSetWithBeaconsMock = updateBeaconSetWithBeaconsSpy.mockImplementation(async () => ({
       hash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
     }));
-    jest.spyOn(DapiServerFactory, 'connect').mockImplementation(
+    jest.spyOn(Api3ServerV1Factory, 'connect').mockImplementation(
       (_dapiServerAddress, _provider) =>
         ({
           connect(_signerOrProvider: ethers.Signer | ethers.providers.Provider | string) {
             return this;
           },
-          updateDataFeedWithSignedData: updateDataFeedWithSignedDataMock,
+          updateBeaconSetWithBeacons: updateBeaconSetWithBeaconsMock,
           dataFeeds: dataFeedsSpy,
         } as any)
     );
@@ -341,38 +341,11 @@ describe('updateBeaconSets', () => {
     await api.updateBeaconSets(groups[0], Date.now());
 
     expect(dataFeedsSpy).toHaveBeenCalled();
-    expect(updateDataFeedWithSignedDataSpy).toHaveBeenCalledWith(
+    expect(updateBeaconSetWithBeaconsSpy).toHaveBeenCalledWith(
       [
-        ethers.utils.defaultAbiCoder.encode(
-          ['address', 'bytes32', 'uint256', 'bytes', 'bytes'],
-          [
-            '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
-            '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa',
-            validSignedData.timestamp,
-            validSignedData.encodedValue,
-            validSignedData.signature,
-          ]
-        ),
-        ethers.utils.defaultAbiCoder.encode(
-          ['address', 'bytes32', 'uint256', 'bytes', 'bytes'],
-          [
-            '0x5656D3A378B1AAdFDDcF4196ea364A9d78617290',
-            '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa',
-            timestamp - 30,
-            '0x',
-            '0x',
-          ]
-        ),
-        ethers.utils.defaultAbiCoder.encode(
-          ['address', 'bytes32', 'uint256', 'bytes', 'bytes'],
-          [
-            '0x5656D3A378B1AAdFDDcF4196ea364A9d78617290',
-            '0x9ec34b00a5019442dcd05a4860ff2bf015164b368cb83fcb756088fcabcdabcd',
-            validSignedData.timestamp,
-            validSignedData.encodedValue,
-            validSignedData.signature,
-          ]
-        ),
+        '0x2ba0526238b0f2671b7981fd7a263730619c8e849a528088fd4a92350a8c2f2c',
+        '0xa5ddf304a7dcec62fa55449b7fe66b33339fd8b249db06c18423d5b0da7716c2',
+        '0x8fa9d00cb8f2d95b1299623d97a97696ed03d0e3350e4ea638f469beabcdabcd',
       ],
       expect.objectContaining({
         gasLimit: expect.any(ethers.BigNumber),
@@ -402,7 +375,7 @@ describe('updateBeaconSets', () => {
     const dataFeedsSpy = jest
       .fn()
       .mockReturnValueOnce(Promise.resolve({ timestamp: timestamp - 25, value: ethers.BigNumber.from(40000000000) }));
-    jest.spyOn(DapiServerFactory, 'connect').mockImplementation(
+    jest.spyOn(Api3ServerV1Factory, 'connect').mockImplementation(
       (_dapiServerAddress, _provider) =>
         ({
           connect(_signerOrProvider: ethers.Signer | ethers.providers.Provider | string) {

--- a/src/update-data-feeds.test.ts
+++ b/src/update-data-feeds.test.ts
@@ -58,7 +58,7 @@ const config: Config = {
   chains: {
     '1': {
       contracts: {
-        DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
       },
       providers: {
         selfHostedMainnet: {
@@ -94,7 +94,7 @@ const config: Config = {
     },
     '3': {
       contracts: {
-        DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
       },
       providers: {
         infuraRopsten: {
@@ -297,7 +297,7 @@ describe('updateDataFeedsInLoop', () => {
 });
 
 describe('updateBeaconSets', () => {
-  it('calls updateBeaconSetWithBeacons in DapiServer contract', async () => {
+  it('calls updateBeaconSetWithBeacons in Api3ServerV1 contract', async () => {
     state.updateState((currentState) => ({
       ...currentState,
       beaconValues: {
@@ -326,7 +326,7 @@ describe('updateBeaconSets', () => {
       hash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
     }));
     jest.spyOn(Api3ServerV1Factory, 'connect').mockImplementation(
-      (_dapiServerAddress, _provider) =>
+      (_api3ServerV1Address, _provider) =>
         ({
           connect(_signerOrProvider: ethers.Signer | ethers.providers.Provider | string) {
             return this;
@@ -376,7 +376,7 @@ describe('updateBeaconSets', () => {
       .fn()
       .mockReturnValueOnce(Promise.resolve({ timestamp: timestamp - 25, value: ethers.BigNumber.from(40000000000) }));
     jest.spyOn(Api3ServerV1Factory, 'connect').mockImplementation(
-      (_dapiServerAddress, _provider) =>
+      (_api3ServerV1, _provider) =>
         ({
           connect(_signerOrProvider: ethers.Signer | ethers.providers.Provider | string) {
             return this;

--- a/src/update-data-feeds.ts
+++ b/src/update-data-feeds.ts
@@ -4,12 +4,7 @@ import { getGasPrice } from '@api3/airnode-utilities';
 import { ethers } from 'ethers';
 import { isEmpty, isNil } from 'lodash';
 import { calculateBeaconSetTimestamp, calculateMedian } from './calculations';
-import {
-  checkFulfillmentDataTimestamp,
-  checkFulfillmentDataValue,
-  checkOnchainDataFreshness,
-  checkUpdateCondition,
-} from './check-condition';
+import { checkFulfillmentDataTimestamp, checkOnchainDataFreshness, checkUpdateCondition } from './check-condition';
 import { INT224_MAX, INT224_MIN, NO_DATA_FEEDS_EXIT_CODE } from './constants';
 import { logger } from './logging';
 import { getState, Provider } from './state';
@@ -206,13 +201,6 @@ export const updateBeacons = async (providerSponsorBeacons: ProviderSponsorDataF
       continue;
     }
 
-    // Check that fulfillment data value updates the on chain data value
-    const isValueChanged = checkFulfillmentDataValue(onChainData, newBeaconValue);
-    if (!isValueChanged) {
-      logger.warn(`Fulfillment data value is same with the on-chain data value. Skipping.`, logOptionsBeaconId);
-      continue;
-    }
-
     // Check that on chain data is newer than heartbeat interval
     const isOnchainDataFresh = checkOnchainDataFreshness(onChainData.timestamp, beaconUpdateData.heartbeatInterval);
     if (!isOnchainDataFresh) {
@@ -405,16 +393,6 @@ export const updateBeaconSets = async (providerSponsorBeacons: ProviderSponsorDa
     const isFulfillmentDataFresh = checkFulfillmentDataTimestamp(beaconSetOnChainData.timestamp, newBeaconSetTimestamp);
     if (!isFulfillmentDataFresh) {
       logger.warn(`Fulfillment data older than on-chain beacon set data. Skipping.`, logOptionsBeaconSetId);
-      continue;
-    }
-
-    // Check that fulfillment data value updates the on chain data value
-    const isValueChanged = checkFulfillmentDataValue(beaconSetOnChainData, newBeaconSetValue);
-    if (!isValueChanged) {
-      logger.warn(
-        `Fulfillment data value is same with the on-chain beacon set data value. Skipping.`,
-        logOptionsBeaconSetId
-      );
       continue;
     }
 

--- a/src/update-data-feeds.ts
+++ b/src/update-data-feeds.ts
@@ -121,7 +121,7 @@ export const initializeUpdateCycle = (
   const totalTimeout = updateInterval * 1_000;
 
   // Prepare contract for beacon updates
-  const contractAddress = config.chains[chainId].contracts['DapiServer'];
+  const contractAddress = config.chains[chainId].contracts['Api3ServerV1'];
   const contract = Api3ServerV1Factory.connect(contractAddress, rpcProvider);
 
   const sponsorWallet = new ethers.Wallet(sponsorWalletsPrivateKey[sponsorAddress]).connect(rpcProvider);

--- a/src/update-data-feeds.ts
+++ b/src/update-data-feeds.ts
@@ -1,13 +1,13 @@
-import { DapiServer__factory as DapiServerFactory } from '@api3/airnode-protocol-v1';
+import { Api3ServerV1__factory as Api3ServerV1Factory } from '@api3/airnode-protocol-v1';
 import { go } from '@api3/promise-utils';
 import { getGasPrice } from '@api3/airnode-utilities';
 import { ethers } from 'ethers';
 import { isEmpty, isNil } from 'lodash';
-import { calculateMedian } from './calculations';
+import { calculateBeaconSetTimestamp, calculateMedian } from './calculations';
 import {
-  checkBeaconSetSignedDataFreshness,
+  checkFulfillmentDataTimestamp,
+  checkFulfillmentDataValue,
   checkOnchainDataFreshness,
-  checkBeaconSignedDataFreshness,
   checkUpdateCondition,
 } from './check-condition';
 import { INT224_MAX, INT224_MIN, NO_DATA_FEEDS_EXIT_CODE } from './constants';
@@ -122,7 +122,7 @@ export const initializeUpdateCycle = (
 
   // Prepare contract for beacon updates
   const contractAddress = config.chains[chainId].contracts['DapiServer'];
-  const contract = DapiServerFactory.connect(contractAddress, rpcProvider);
+  const contract = Api3ServerV1Factory.connect(contractAddress, rpcProvider);
 
   const sponsorWallet = new ethers.Wallet(sponsorWalletsPrivateKey[sponsorAddress]).connect(rpcProvider);
 
@@ -196,10 +196,20 @@ export const updateBeacons = async (providerSponsorBeacons: ProviderSponsorDataF
       continue;
     }
 
-    // Check that signed data is newer than on chain value
-    const isSignedDataFresh = checkBeaconSignedDataFreshness(onChainData.timestamp, newBeaconResponse.timestamp);
-    if (!isSignedDataFresh) {
-      logger.warn(`Signed data older than on chain record. Skipping.`, logOptionsBeaconId);
+    // Check that fulfillment data is newer than on chain data
+    const isFulfillmentDataFresh = checkFulfillmentDataTimestamp(
+      onChainData.timestamp,
+      parseInt(newBeaconResponse.timestamp, 10)
+    );
+    if (!isFulfillmentDataFresh) {
+      logger.warn(`Fulfillment data older than on-chain data. Skipping.`, logOptionsBeaconId);
+      continue;
+    }
+
+    // Check that fulfillment data value updates the on chain data value
+    const isValueChanged = checkFulfillmentDataValue(onChainData, newBeaconValue);
+    if (!isValueChanged) {
+      logger.warn(`Fulfillment data value is same with the on-chain data value. Skipping.`, logOptionsBeaconId);
       continue;
     }
 
@@ -253,19 +263,12 @@ export const updateBeacons = async (providerSponsorBeacons: ProviderSponsorDataF
       () =>
         contract
           .connect(sponsorWallet)
-          .updateDataFeedWithSignedData(
-            [
-              ethers.utils.defaultAbiCoder.encode(
-                ['address', 'bytes32', 'uint256', 'bytes', 'bytes'],
-                [
-                  beaconUpdateData.airnode,
-                  beaconUpdateData.templateId,
-                  newBeaconResponse.timestamp,
-                  newBeaconResponse.encodedValue,
-                  newBeaconResponse.signature,
-                ]
-              ),
-            ],
+          .updateBeaconWithSignedData(
+            beaconUpdateData.airnode,
+            beaconUpdateData.templateId,
+            newBeaconResponse.timestamp,
+            newBeaconResponse.encodedValue,
+            newBeaconResponse.signature,
             {
               nonce,
               ...gasTarget,
@@ -324,8 +327,8 @@ export const updateBeaconSets = async (providerSponsorBeacons: ProviderSponsorDa
       logger.warn(`Unable to read data feed. Error: ${goDataFeed.error}`, logOptionsBeaconSetId);
       continue;
     }
-    const beaconSetValueOnChain = goDataFeed.data;
-    if (!beaconSetValueOnChain) {
+    const beaconSetOnChainData = goDataFeed.data;
+    if (!beaconSetOnChainData) {
       const message = `Missing on chain data for beaconSet. Skipping.`;
       logger.warn(message, logOptionsBeaconSetId);
       continue;
@@ -395,17 +398,28 @@ export const updateBeaconSets = async (providerSponsorBeacons: ProviderSponsorDa
       (result) => (result as PromiseFulfilledResult<BeaconSetBeaconValue>).value
     );
 
-    const isSignedDataFresh = checkBeaconSetSignedDataFreshness(
-      beaconSetValueOnChain.timestamp,
-      beaconSetBeaconValues.map((value) => value.timestamp)
-    );
-    if (!isSignedDataFresh) {
-      logger.info('On chain beacon set value is more up-to-date. Skipping.');
+    const newBeaconSetValue = calculateMedian(beaconSetBeaconValues.map((value) => value.value));
+    const newBeaconSetTimestamp = calculateBeaconSetTimestamp(beaconSetBeaconValues.map((value) => value.timestamp));
+
+    // Check that fulfillment data is newer than on chain data
+    const isFulfillmentDataFresh = checkFulfillmentDataTimestamp(beaconSetOnChainData.timestamp, newBeaconSetTimestamp);
+    if (!isFulfillmentDataFresh) {
+      logger.warn(`Fulfillment data older than on-chain beacon set data. Skipping.`, logOptionsBeaconSetId);
+      continue;
+    }
+
+    // Check that fulfillment data value updates the on chain data value
+    const isValueChanged = checkFulfillmentDataValue(beaconSetOnChainData, newBeaconSetValue);
+    if (!isValueChanged) {
+      logger.warn(
+        `Fulfillment data value is same with the on-chain beacon set data value. Skipping.`,
+        logOptionsBeaconSetId
+      );
       continue;
     }
 
     // Check that on chain data is newer than heartbeat interval
-    const isOnchainDataFresh = checkOnchainDataFreshness(beaconSetValueOnChain.timestamp, beaconSet.heartbeatInterval);
+    const isOnchainDataFresh = checkOnchainDataFreshness(beaconSetOnChainData.timestamp, beaconSet.heartbeatInterval);
     if (!isOnchainDataFresh) {
       logger.info(
         `On chain data timestamp older than heartbeat. Updating without condition check.`,
@@ -414,11 +428,10 @@ export const updateBeaconSets = async (providerSponsorBeacons: ProviderSponsorDa
     } else {
       // Check beacon set condition
       // If the deviation threshold is reached do the update, skip otherwise
-      const updatedValue = calculateMedian(beaconSetBeaconValues.map((value) => value.value));
       const shouldUpdate = checkUpdateCondition(
-        beaconSetValueOnChain.value,
+        beaconSetOnChainData.value,
         beaconSet.deviationThreshold,
-        updatedValue
+        newBeaconSetValue
       );
       if (shouldUpdate === null) {
         logger.warn(`Unable to fetch current beacon set value`, logOptionsBeaconSetId);
@@ -454,13 +467,8 @@ export const updateBeaconSets = async (providerSponsorBeacons: ProviderSponsorDa
     // Update beacon set
     const tx = await go(
       () =>
-        contract.connect(sponsorWallet).updateDataFeedWithSignedData(
-          beaconSetBeaconValues.map(({ airnode, templateId, timestamp, encodedValue, signature }) =>
-            ethers.utils.defaultAbiCoder.encode(
-              ['address', 'bytes32', 'uint256', 'bytes', 'bytes'],
-              [airnode, templateId, timestamp, encodedValue, signature]
-            )
-          ),
+        contract.connect(sponsorWallet).updateBeaconSetWithBeacons(
+          beaconSetBeaconValues.map(({ beaconId }) => beaconId),
           {
             nonce,
             ...gasTarget,

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -22,18 +22,18 @@ it('successfully parses example configuration', () => {
   expect(() => configSchema.parse(interpolatedConfig)).not.toThrow();
 });
 
-it('fails if chain is missing DapiServer contract address', () => {
+it('fails if chain is missing Api3ServerV1 contract address', () => {
   const config: Config = JSON.parse(
     fs.readFileSync(path.join(__dirname, '..', 'config', 'airseeker.example.json'), 'utf8')
   );
-  delete config.chains['1'].contracts['DapiServer'];
+  delete config.chains['1'].contracts['Api3ServerV1'];
   const interpolatedConfig = interpolateSecrets(config, envVariables);
 
   expect(() => configSchema.parse(interpolatedConfig)).toThrow(
     new ZodError([
       {
         code: 'custom',
-        message: 'DapiServer contract address is missing',
+        message: 'Api3ServerV1 contract address is missing',
         path: ['chains', '1', 'contracts'],
       },
     ])

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -61,8 +61,8 @@ export const providerSchema = z
 export const chainSchema = z
   .object({
     contracts: z.record(config.evmAddressSchema).refine((contracts) => {
-      return !isNil(contracts['DapiServer']);
-    }, 'DapiServer contract address is missing'),
+      return !isNil(contracts['Api3ServerV1']);
+    }, 'Api3ServerV1 contract address is missing'),
     providers: z.record(providerSchema),
     options: config.chainOptionsSchema,
   })

--- a/test/e2e/airseeker.feature.ts
+++ b/test/e2e/airseeker.feature.ts
@@ -260,7 +260,7 @@ describe('Airseeker', () => {
         chains: {
           '31337': {
             contracts: {
-              Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+              Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
             },
             providers: {
               invalidProvider: {

--- a/test/e2e/airseeker.feature.ts
+++ b/test/e2e/airseeker.feature.ts
@@ -3,7 +3,7 @@ import { ContractFactory, Contract, Wallet } from 'ethers';
 import * as hre from 'hardhat';
 import '@nomiclabs/hardhat-ethers';
 import { buildAirseekerConfig, buildLocalSecrets } from '../fixtures/config';
-import { deployAndUpdateSubscriptions } from '../setup/deployment';
+import { deployAndUpdate } from '../setup/deployment';
 import { main, handleStopSignal } from '../../src/main';
 import { sleep } from '../../src/utils';
 import * as makeRequest from '../../src/make-request';
@@ -24,14 +24,11 @@ describe('Airseeker', () => {
     accessControlRegistry: Contract;
     airnodeProtocolFactory: ContractFactory;
     airnodeProtocol: Contract;
-    dapiServerFactory: ContractFactory;
+    api3ServerV1Factory: ContractFactory;
     dapiServer: Contract;
     templateIdETH: string;
     templateIdBTC: string;
-    airnodePspSponsorWallet: Wallet;
     airnodeWallet: Wallet;
-    subscriptionIdETH: string;
-    subscriptionIdBTC: string;
     beaconIdETH: string;
     beaconIdBTC: string;
     beaconIdLTC: string;
@@ -49,7 +46,7 @@ describe('Airseeker', () => {
     jest.restoreAllMocks();
     jest.clearAllTimers();
 
-    deployment = await deployAndUpdateSubscriptions();
+    deployment = await deployAndUpdate();
   });
 
   it('updates the beacons successfully', async () => {

--- a/test/e2e/airseeker.feature.ts
+++ b/test/e2e/airseeker.feature.ts
@@ -22,10 +22,8 @@ describe('Airseeker', () => {
   let deployment: {
     accessControlRegistryFactory: ContractFactory;
     accessControlRegistry: Contract;
-    airnodeProtocolFactory: ContractFactory;
-    airnodeProtocol: Contract;
     api3ServerV1Factory: ContractFactory;
-    dapiServer: Contract;
+    api3ServerV1: Contract;
     templateIdETH: string;
     templateIdBTC: string;
     airnodeWallet: Wallet;
@@ -51,13 +49,13 @@ describe('Airseeker', () => {
 
   it('updates the beacons successfully', async () => {
     const voidSigner = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, provider);
-    const dapiServer = deployment.dapiServer.connect(voidSigner);
+    const api3ServerV1 = deployment.api3ServerV1.connect(voidSigner);
 
     // Check that initial values are updated
-    const beaconValueETH = await dapiServer.dataFeeds(deployment.beaconIdETH);
-    const beaconValueBTC = await dapiServer.dataFeeds(deployment.beaconIdBTC);
-    const beaconValueLTC = await dapiServer.dataFeeds(deployment.beaconIdLTC);
-    const beaconSetValue = await dapiServer.dataFeeds(deployment.beaconSetId);
+    const beaconValueETH = await api3ServerV1.dataFeeds(deployment.beaconIdETH);
+    const beaconValueBTC = await api3ServerV1.dataFeeds(deployment.beaconIdBTC);
+    const beaconValueLTC = await api3ServerV1.dataFeeds(deployment.beaconIdLTC);
+    const beaconSetValue = await api3ServerV1.dataFeeds(deployment.beaconSetId);
 
     expect(beaconValueETH.value).toEqual(hre.ethers.BigNumber.from(723.39202 * 1_000_000));
     expect(beaconValueBTC.value).toEqual(hre.ethers.BigNumber.from(41_091.12345 * 1_000_000));
@@ -75,10 +73,10 @@ describe('Airseeker', () => {
       await sleep(20_000);
     });
 
-    const beaconValueETHNew = await dapiServer.dataFeeds(deployment.beaconIdETH);
-    const beaconValueBTCNew = await dapiServer.dataFeeds(deployment.beaconIdBTC);
-    const beaconValueLTCNew = await dapiServer.dataFeeds(deployment.beaconIdLTC);
-    const beaconSetValueNew = await dapiServer.dataFeeds(deployment.beaconSetId);
+    const beaconValueETHNew = await api3ServerV1.dataFeeds(deployment.beaconIdETH);
+    const beaconValueBTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdBTC);
+    const beaconValueLTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdLTC);
+    const beaconSetValueNew = await api3ServerV1.dataFeeds(deployment.beaconSetId);
 
     expect(beaconValueETHNew.value).toEqual(hre.ethers.BigNumber.from(800 * 1_000_000));
     expect(beaconValueBTCNew.value).toEqual(hre.ethers.BigNumber.from(43_000 * 1_000_000));
@@ -88,14 +86,14 @@ describe('Airseeker', () => {
 
   it('does not update if the condition check fails', async () => {
     const voidSigner = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, provider);
-    const dapiServer = deployment.dapiServer.connect(voidSigner);
+    const api3ServerV1 = deployment.api3ServerV1.connect(voidSigner);
 
     // Check that initial values are updated
-    const beaconValueETH = await dapiServer.dataFeeds(deployment.beaconIdETH);
-    const beaconValueBTC = await dapiServer.dataFeeds(deployment.beaconIdBTC);
-    const beaconValueLTC = await dapiServer.dataFeeds(deployment.beaconIdLTC);
+    const beaconValueETH = await api3ServerV1.dataFeeds(deployment.beaconIdETH);
+    const beaconValueBTC = await api3ServerV1.dataFeeds(deployment.beaconIdBTC);
+    const beaconValueLTC = await api3ServerV1.dataFeeds(deployment.beaconIdLTC);
     expect(beaconValueLTC.value).toEqual(hre.ethers.constants.Zero);
-    const beaconSetValue = await dapiServer.dataFeeds(deployment.beaconSetId);
+    const beaconSetValue = await api3ServerV1.dataFeeds(deployment.beaconSetId);
 
     mockReadFileSync(
       'airseeker.json',
@@ -146,10 +144,10 @@ describe('Airseeker', () => {
       await sleep(20_000);
     });
 
-    const beaconValueETHNew = await dapiServer.dataFeeds(deployment.beaconIdETH);
-    const beaconValueBTCNew = await dapiServer.dataFeeds(deployment.beaconIdBTC);
-    const beaconValueLTCNew = await dapiServer.dataFeeds(deployment.beaconIdLTC);
-    const beaconSetValueNew = await dapiServer.dataFeeds(deployment.beaconSetId);
+    const beaconValueETHNew = await api3ServerV1.dataFeeds(deployment.beaconIdETH);
+    const beaconValueBTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdBTC);
+    const beaconValueLTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdLTC);
+    const beaconSetValueNew = await api3ServerV1.dataFeeds(deployment.beaconSetId);
 
     expect(beaconValueETHNew.value).toEqual(beaconValueETH.value);
     expect(beaconValueBTCNew.value).toEqual(beaconValueBTC.value);
@@ -158,7 +156,7 @@ describe('Airseeker', () => {
     expect(beaconSetValueNew.value).toEqual(beaconSetValue.value);
   });
 
-  it('updates if the DapiServer timestamp is older than heartbeatInterval', async () => {
+  it('updates if the Api3ServerV1 timestamp is older than heartbeatInterval', async () => {
     mockReadFileSync(
       'airseeker.json',
       JSON.stringify({
@@ -209,12 +207,12 @@ describe('Airseeker', () => {
     });
 
     const voidSigner = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, provider);
-    const dapiServer = deployment.dapiServer.connect(voidSigner);
+    const api3ServerV1 = deployment.api3ServerV1.connect(voidSigner);
 
-    const beaconValueETHNew = await dapiServer.dataFeeds(deployment.beaconIdETH);
-    const beaconValueBTCNew = await dapiServer.dataFeeds(deployment.beaconIdBTC);
-    const beaconValueLTCNew = await dapiServer.dataFeeds(deployment.beaconIdLTC);
-    const beaconSetValueNew = await dapiServer.dataFeeds(deployment.beaconSetId);
+    const beaconValueETHNew = await api3ServerV1.dataFeeds(deployment.beaconIdETH);
+    const beaconValueBTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdBTC);
+    const beaconValueLTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdLTC);
+    const beaconSetValueNew = await api3ServerV1.dataFeeds(deployment.beaconSetId);
 
     expect(beaconValueETHNew.value).toEqual(hre.ethers.BigNumber.from(800 * 1_000_000));
     expect(beaconValueBTCNew.value).toEqual(hre.ethers.BigNumber.from(43_000 * 1_000_000));
@@ -241,12 +239,12 @@ describe('Airseeker', () => {
     });
 
     const voidSigner = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, provider);
-    const dapiServer = deployment.dapiServer.connect(voidSigner);
+    const api3ServerV1 = deployment.api3ServerV1.connect(voidSigner);
 
-    const beaconValueETHNew = await dapiServer.dataFeeds(deployment.beaconIdETH);
-    const beaconValueBTCNew = await dapiServer.dataFeeds(deployment.beaconIdBTC);
-    const beaconValueLTCNew = await dapiServer.dataFeeds(deployment.beaconIdLTC);
-    const beaconSetValueNew = await dapiServer.dataFeeds(deployment.beaconSetId);
+    const beaconValueETHNew = await api3ServerV1.dataFeeds(deployment.beaconIdETH);
+    const beaconValueBTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdBTC);
+    const beaconValueLTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdLTC);
+    const beaconSetValueNew = await api3ServerV1.dataFeeds(deployment.beaconSetId);
 
     expect(beaconValueETHNew.value).toEqual(hre.ethers.BigNumber.from(800 * 1_000_000));
     expect(beaconValueBTCNew.value).toEqual(hre.ethers.BigNumber.from(43_000 * 1_000_000));
@@ -262,7 +260,7 @@ describe('Airseeker', () => {
         chains: {
           '31337': {
             contracts: {
-              DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+              Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
             },
             providers: {
               invalidProvider: {
@@ -310,12 +308,12 @@ describe('Airseeker', () => {
     });
 
     const voidSigner = new hre.ethers.VoidSigner(hre.ethers.constants.AddressZero, provider);
-    const dapiServer = deployment.dapiServer.connect(voidSigner);
+    const api3ServerV1 = deployment.api3ServerV1.connect(voidSigner);
 
-    const beaconValueETHNew = await dapiServer.dataFeeds(deployment.beaconIdETH);
-    const beaconValueBTCNew = await dapiServer.dataFeeds(deployment.beaconIdBTC);
-    const beaconValueLTCNew = await dapiServer.dataFeeds(deployment.beaconIdLTC);
-    const beaconSetValueNew = await dapiServer.dataFeeds(deployment.beaconSetId);
+    const beaconValueETHNew = await api3ServerV1.dataFeeds(deployment.beaconIdETH);
+    const beaconValueBTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdBTC);
+    const beaconValueLTCNew = await api3ServerV1.dataFeeds(deployment.beaconIdLTC);
+    const beaconSetValueNew = await api3ServerV1.dataFeeds(deployment.beaconSetId);
 
     expect(beaconValueETHNew.value).toEqual(hre.ethers.BigNumber.from(800 * 1_000_000));
     expect(beaconValueBTCNew.value).toEqual(hre.ethers.BigNumber.from(43_000 * 1_000_000));

--- a/test/e2e/check-condition.feature.ts
+++ b/test/e2e/check-condition.feature.ts
@@ -1,8 +1,8 @@
 import { ethers } from 'ethers';
 import * as hre from 'hardhat';
-import { DapiServer__factory as DapiServerFactory } from '@api3/airnode-protocol-v1';
+import { Api3ServerV1__factory as Api3ServerV1Factory } from '@api3/airnode-protocol-v1';
 import { checkUpdateCondition } from '../../src/check-condition';
-import { deployAndUpdateSubscriptions } from '../setup/deployment';
+import { deployAndUpdate } from '../setup/deployment';
 
 // Jest version 27 has a bug where jest.setTimeout does not work correctly inside describe or test blocks
 // https://github.com/facebook/jest/issues/11607
@@ -11,7 +11,7 @@ jest.setTimeout(60_000);
 const providerUrl = 'http://127.0.0.1:8545/';
 const provider = new ethers.providers.StaticJsonRpcProvider(providerUrl);
 const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-const dapiServer = DapiServerFactory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
+const dapiServer = Api3ServerV1Factory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
 
 const apiValue = 723.39202;
 const _times = 1_000_000;
@@ -34,7 +34,7 @@ describe('checkUpdateCondition', () => {
 
     jest.restoreAllMocks();
 
-    const { airnodeWallet, templateIdETH } = await deployAndUpdateSubscriptions();
+    const { airnodeWallet, templateIdETH } = await deployAndUpdate();
     beaconId = ethers.utils.keccak256(
       ethers.utils.solidityPack(['address', 'bytes32'], [airnodeWallet.address, templateIdETH])
     );

--- a/test/e2e/check-condition.feature.ts
+++ b/test/e2e/check-condition.feature.ts
@@ -11,7 +11,7 @@ jest.setTimeout(60_000);
 const providerUrl = 'http://127.0.0.1:8545/';
 const provider = new ethers.providers.StaticJsonRpcProvider(providerUrl);
 const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-const api3ServerV1 = Api3ServerV1Factory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
+const api3ServerV1 = Api3ServerV1Factory.connect('0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512', provider);
 
 const apiValue = 723.39202;
 const _times = 1_000_000;

--- a/test/e2e/check-condition.feature.ts
+++ b/test/e2e/check-condition.feature.ts
@@ -11,7 +11,7 @@ jest.setTimeout(60_000);
 const providerUrl = 'http://127.0.0.1:8545/';
 const provider = new ethers.providers.StaticJsonRpcProvider(providerUrl);
 const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-const dapiServer = Api3ServerV1Factory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
+const api3ServerV1 = Api3ServerV1Factory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
 
 const apiValue = 723.39202;
 const _times = 1_000_000;
@@ -39,7 +39,7 @@ describe('checkUpdateCondition', () => {
       ethers.utils.solidityPack(['address', 'bytes32'], [airnodeWallet.address, templateIdETH])
     );
 
-    onChainValue = (await dapiServer.connect(voidSigner).dataFeeds(beaconId))!;
+    onChainValue = (await api3ServerV1.connect(voidSigner).dataFeeds(beaconId))!;
   });
 
   it('returns true for increase above the deviationThreshold', () => {

--- a/test/e2e/update-data-feeds.feature.ts
+++ b/test/e2e/update-data-feeds.feature.ts
@@ -17,7 +17,7 @@ jest.setTimeout(60_000);
 const providerUrl = 'http://127.0.0.1:8545/';
 const provider = new ethers.providers.StaticJsonRpcProvider(providerUrl);
 const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-const dapiServer = Api3ServerV1Factory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
+const api3ServerV1 = Api3ServerV1Factory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
 
 describe('updateDataFeeds', () => {
   beforeEach(async () => {
@@ -52,19 +52,19 @@ describe('updateDataFeeds', () => {
     state.updateState((oldState) => ({ ...oldState, stopSignalReceived: true }));
     await utils.sleep(8_000);
 
-    const beaconDataETH = await dapiServer
+    const beaconDataETH = await api3ServerV1
       .connect(voidSigner)
       .dataFeeds('0x924b5d4cb3ec6366ae4302a1ca6aec035594ea3ea48a102d160b50b0c43ebfb5');
     expect(beaconDataETH.value.toString()).toEqual('738149047');
-    const beaconDataBTC = await dapiServer
+    const beaconDataBTC = await api3ServerV1
       .connect(voidSigner)
       .dataFeeds('0xbf7ce55d109fd196de2a8bf1515d166c56c9decbe9cb473656bbca30d5743990');
     expect(beaconDataBTC.value.toString()).toEqual('41091123450');
-    const beaconDataLTC = await dapiServer
+    const beaconDataLTC = await api3ServerV1
       .connect(voidSigner)
       .dataFeeds('0x9b5825decf1232f79d3408fb6f7eeb7050fd88037f6517a94914e7d01ccd0cef');
     expect(beaconDataLTC.value.toString()).toEqual('51420000');
-    const beaconSetData = await dapiServer
+    const beaconSetData = await api3ServerV1
       .connect(voidSigner)
       .dataFeeds('0xf7f1620b7f422eb9a69c8e21b317ba1555d3d87e1d804f0b024f03b107e411e8');
     expect(beaconSetData.value.toString()).toEqual('20914636248');

--- a/test/e2e/update-data-feeds.feature.ts
+++ b/test/e2e/update-data-feeds.feature.ts
@@ -1,11 +1,11 @@
 import { ethers } from 'ethers';
 import * as hre from 'hardhat';
-import { DapiServer__factory as DapiServerFactory } from '@api3/airnode-protocol-v1';
+import { Api3ServerV1__factory as Api3ServerV1Factory } from '@api3/airnode-protocol-v1';
 import { initiateDataFeedUpdates } from '../../src/update-data-feeds';
 import * as utils from '../../src/utils';
 import * as state from '../../src/state';
 import { initializeProviders } from '../../src/providers';
-import { deployAndUpdateSubscriptions } from '../setup/deployment';
+import { deployAndUpdate } from '../setup/deployment';
 import { buildAirseekerConfig, buildLocalSecrets } from '../fixtures/config';
 import { parseConfigWithSecrets } from '../../src/config';
 import { initializeWallets } from '../../src/wallets';
@@ -17,7 +17,7 @@ jest.setTimeout(60_000);
 const providerUrl = 'http://127.0.0.1:8545/';
 const provider = new ethers.providers.StaticJsonRpcProvider(providerUrl);
 const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-const dapiServer = DapiServerFactory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
+const dapiServer = Api3ServerV1Factory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
 
 describe('updateDataFeeds', () => {
   beforeEach(async () => {
@@ -30,7 +30,7 @@ describe('updateDataFeeds', () => {
 
     jest.restoreAllMocks();
 
-    const { beaconIdETH, beaconIdLTC, signedDataETH, signedDataLTC } = await deployAndUpdateSubscriptions();
+    const { beaconIdETH, beaconIdLTC, signedDataETH, signedDataLTC } = await deployAndUpdate();
     const config = parseConfigWithSecrets(buildAirseekerConfig(), buildLocalSecrets());
     if (!config.success) {
       throw new Error('Invalid configuration fixture');

--- a/test/e2e/update-data-feeds.feature.ts
+++ b/test/e2e/update-data-feeds.feature.ts
@@ -17,7 +17,7 @@ jest.setTimeout(60_000);
 const providerUrl = 'http://127.0.0.1:8545/';
 const provider = new ethers.providers.StaticJsonRpcProvider(providerUrl);
 const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-const api3ServerV1 = Api3ServerV1Factory.connect('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', provider);
+const api3ServerV1 = Api3ServerV1Factory.connect('0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512', provider);
 
 describe('updateDataFeeds', () => {
   beforeEach(async () => {

--- a/test/fixtures/config.ts
+++ b/test/fixtures/config.ts
@@ -33,7 +33,7 @@ export const buildAirseekerConfig = () => ({
   chains: {
     '31337': {
       contracts: {
-        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
       },
       providers: {
         local: {

--- a/test/fixtures/config.ts
+++ b/test/fixtures/config.ts
@@ -33,7 +33,7 @@ export const buildAirseekerConfig = () => ({
   chains: {
     '31337': {
       contracts: {
-        DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+        Api3ServerV1: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
       },
       providers: {
         local: {

--- a/test/setup/deployment.ts
+++ b/test/setup/deployment.ts
@@ -7,13 +7,11 @@ import * as protocol from '@api3/airnode-protocol';
 import {
   AccessControlRegistry__factory as AccessControlRegistryFactory,
   AirnodeProtocol__factory as AirnodeProtocolFactory,
-  DapiServer__factory as DapiServerFactory,
+  Api3ServerV1__factory as Api3ServerV1Factory,
 } from '@api3/airnode-protocol-v1';
 import { buildLocalConfigETH, buildLocalConfigBTC, buildLocalConfigLTC } from '../fixtures/config';
+import { SignedData } from '../../src/validation';
 
-const subscriptionIdETH = '0xc1ed31de05a9aa74410c24bccd6aa40235006f9063f1c65d47401e97ad04560e';
-const subscriptionIdBTC = '0xb4c3cea3b78c384eb4409df1497bb2f1fd872f1928a218f8907c38fe0d66ffea';
-// const subscriptionIdLTC = '0x74d8547ed2a09b41eb376455f65996a21b2e22fd832534d126639e3eec3a5c13';
 const provider = new hre.ethers.providers.StaticJsonRpcProvider('http://127.0.0.1:8545');
 const localConfigETH = buildLocalConfigETH();
 
@@ -24,60 +22,55 @@ const roles = {
   randomPerson: new hre.ethers.Wallet(localConfigETH.privateKeys.randomPerson).connect(provider),
 };
 
-const getTimestampAndSignature = async (airnodeWallet: Wallet, subscriptionId: string, sponsorWallet: Wallet) => {
-  const timestamp = (await provider.getBlock('latest')).timestamp + 1;
-
-  const signature = await airnodeWallet.signMessage(
-    hre.ethers.utils.arrayify(
-      hre.ethers.utils.keccak256(
-        hre.ethers.utils.solidityPack(
-          ['bytes32', 'uint256', 'address'],
-          [subscriptionId, timestamp, sponsorWallet.address]
-        )
-      )
-    )
-  );
-
-  return { timestamp, signature };
-};
-
-const signData = async (airnodeWallet: Wallet, templateId: string, data: string) => {
-  const timestamp = (await provider.getBlock('latest')).timestamp + 100;
-
-  const signature = await airnodeWallet.signMessage(
-    hre.ethers.utils.arrayify(
-      hre.ethers.utils.keccak256(
-        hre.ethers.utils.solidityPack(['bytes32', 'uint256', 'bytes'], [templateId, timestamp, data || '0x'])
-      )
-    )
-  );
-
-  return { timestamp, signature };
-};
-
-export const updateBeacon = async (
+const updateBeacon = async (
   dapiServer: Contract,
-  airnodePspSponsorWallet: Wallet,
   airnodeWallet: Wallet,
-  subscriptionId: string,
+  airseekerSponsorWallet: Wallet,
+  templateId: string,
   apiValue: number
 ) => {
-  const timestampAndSignature = await getTimestampAndSignature(airnodeWallet, subscriptionId, airnodePspSponsorWallet);
+  const signedData = await signData(
+    airnodeWallet,
+    templateId,
+    (await provider.getBlock('latest')).timestamp + 1,
+    apiValue
+  );
+
   await dapiServer
-    .connect(airnodePspSponsorWallet)
-    .fulfillPspBeaconUpdate(
-      subscriptionId,
+    .connect(airseekerSponsorWallet)
+    .updateBeaconWithSignedData(
       airnodeWallet.address,
-      airnodeWallet.address,
-      roles.sponsor.address,
-      timestampAndSignature.timestamp,
-      hre.ethers.utils.defaultAbiCoder.encode(['int256'], [hre.ethers.BigNumber.from(apiValue)]),
-      timestampAndSignature.signature,
-      { gasLimit: 500_000 }
+      templateId,
+      signedData.timestamp,
+      signedData.encodedValue,
+      signedData.signature
     );
 };
 
-export const deployAndUpdateSubscriptions = async () => {
+const signData = async (
+  airnodeWallet: Wallet,
+  templateId: string,
+  timestamp: number,
+  apiValue: number
+): Promise<SignedData> => {
+  const encodedValue = hre.ethers.utils.defaultAbiCoder.encode(['uint224'], [hre.ethers.BigNumber.from(apiValue)]);
+
+  const signature = await airnodeWallet.signMessage(
+    hre.ethers.utils.arrayify(
+      hre.ethers.utils.keccak256(
+        hre.ethers.utils.solidityPack(['bytes32', 'uint256', 'bytes'], [templateId, timestamp, encodedValue || '0x'])
+      )
+    )
+  );
+
+  return {
+    timestamp: timestamp.toString(),
+    encodedValue,
+    signature,
+  };
+};
+
+export const deployAndUpdate = async () => {
   const dapiServerAdminRoleDescription = 'DapiServer admin';
 
   // Deploy contracts
@@ -95,16 +88,15 @@ export const deployAndUpdateSubscriptions = async () => {
   );
   const airnodeProtocol = await airnodeProtocolFactory.deploy();
 
-  const dapiServerFactory = new hre.ethers.ContractFactory(
-    DapiServerFactory.abi,
-    DapiServerFactory.bytecode,
+  const api3ServerV1Factory = new hre.ethers.ContractFactory(
+    Api3ServerV1Factory.abi,
+    Api3ServerV1Factory.bytecode,
     roles.deployer
   );
-  const dapiServer = await dapiServerFactory.deploy(
+  const dapiServer = await api3ServerV1Factory.deploy(
     accessControlRegistry.address,
     dapiServerAdminRoleDescription,
-    roles.manager.address,
-    airnodeProtocol.address
+    roles.manager.address
   );
 
   // Access control
@@ -115,13 +107,6 @@ export const deployAndUpdateSubscriptions = async () => {
 
   // Wallets
   const airnodeWallet = hre.ethers.Wallet.fromMnemonic(localConfigETH.airnodeMnemonic);
-  const airnodePspSponsorWallet = node.evm
-    .deriveSponsorWalletFromMnemonic(localConfigETH.airnodeMnemonic, roles.sponsor.address, protocol.PROTOCOL_IDS.PSP)
-    .connect(provider);
-  await roles.deployer.sendTransaction({
-    to: airnodePspSponsorWallet.address,
-    value: hre.ethers.utils.parseEther('1'),
-  });
 
   const airseekerSponsorWallet = node.evm
     .deriveSponsorWalletFromMnemonic(
@@ -136,8 +121,7 @@ export const deployAndUpdateSubscriptions = async () => {
     value: hre.ethers.utils.parseEther('1'),
   });
 
-  // Setup ETH Subscription
-  // Templates
+  // Templates for ETH
   const endpointIdETH = hre.ethers.utils.keccak256(
     hre.ethers.utils.defaultAbiCoder.encode(
       ['string', 'string'],
@@ -147,37 +131,8 @@ export const deployAndUpdateSubscriptions = async () => {
   const parametersETH = abi.encode(localConfigETH.templateParameters);
   const templateIdETH = hre.ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [endpointIdETH, parametersETH]);
 
-  // Subscriptions
-  const thresholdETH = (await dapiServer.HUNDRED_PERCENT()).div(localConfigETH.threshold); // Update threshold %
-  const beaconUpdateSubscriptionConditionParametersETH = hre.ethers.utils.defaultAbiCoder.encode(
-    ['uint256'],
-    [thresholdETH]
-  );
-  const beaconUpdateSubscriptionConditionsETH = [
-    {
-      type: 'bytes32',
-      name: '_conditionFunctionId',
-      value: hre.ethers.utils.defaultAbiCoder.encode(
-        ['bytes4'],
-        [dapiServer.interface.getSighash('conditionPspBeaconUpdate')]
-      ),
-    },
-    { type: 'bytes', name: '_conditionParameters', value: beaconUpdateSubscriptionConditionParametersETH },
-  ];
-  const encodedBeaconUpdateSubscriptionConditionsETH = abi.encode(beaconUpdateSubscriptionConditionsETH);
-  await dapiServer
-    .connect(roles.randomPerson)
-    .registerBeaconUpdateSubscription(
-      airnodeWallet.address,
-      templateIdETH,
-      encodedBeaconUpdateSubscriptionConditionsETH,
-      airnodeWallet.address,
-      roles.sponsor.address
-    );
-
-  // Setup BTC Subscription
+  // Templates for BTC
   const localConfigBTC = buildLocalConfigBTC();
-  // Templates
   const endpointIdBTC = hre.ethers.utils.keccak256(
     hre.ethers.utils.defaultAbiCoder.encode(
       ['string', 'string'],
@@ -187,37 +142,8 @@ export const deployAndUpdateSubscriptions = async () => {
   const parametersBTC = abi.encode(localConfigBTC.templateParameters);
   const templateIdBTC = hre.ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [endpointIdBTC, parametersBTC]);
 
-  // Subscriptions
-  const thresholdBTC = (await dapiServer.HUNDRED_PERCENT()).div(localConfigBTC.threshold); // Update threshold %
-  const beaconUpdateSubscriptionConditionParameters2 = hre.ethers.utils.defaultAbiCoder.encode(
-    ['uint256'],
-    [thresholdBTC]
-  );
-  const beaconUpdateSubscriptionConditionsBTC = [
-    {
-      type: 'bytes32',
-      name: '_conditionFunctionId',
-      value: hre.ethers.utils.defaultAbiCoder.encode(
-        ['bytes4'],
-        [dapiServer.interface.getSighash('conditionPspBeaconUpdate')]
-      ),
-    },
-    { type: 'bytes', name: '_conditionParameters', value: beaconUpdateSubscriptionConditionParameters2 },
-  ];
-  const encodedBeaconUpdateSubscriptionConditionsBTC = abi.encode(beaconUpdateSubscriptionConditionsBTC);
-  await dapiServer
-    .connect(roles.randomPerson)
-    .registerBeaconUpdateSubscription(
-      airnodeWallet.address,
-      templateIdBTC,
-      encodedBeaconUpdateSubscriptionConditionsBTC,
-      airnodeWallet.address,
-      roles.sponsor.address
-    );
-
-  // Setup LTC Subscription
+  // Templates for LTC
   const localConfigLTC = buildLocalConfigLTC();
-  // Templates
   const endpointIdLTC = hre.ethers.utils.keccak256(
     hre.ethers.utils.defaultAbiCoder.encode(
       ['string', 'string'],
@@ -227,86 +153,35 @@ export const deployAndUpdateSubscriptions = async () => {
   const parametersLTC = abi.encode(localConfigLTC.templateParameters);
   const templateIdLTC = hre.ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [endpointIdLTC, parametersLTC]);
 
-  // Subscriptions
-  const thresholdLTC = (await dapiServer.HUNDRED_PERCENT()).div(localConfigLTC.threshold); // Update threshold %
-  const beaconUpdateSubscriptionConditionParameters3 = hre.ethers.utils.defaultAbiCoder.encode(
-    ['uint256'],
-    [thresholdLTC]
-  );
-  const beaconUpdateSubscriptionConditionsLTC = [
-    {
-      type: 'bytes32',
-      name: '_conditionFunctionId',
-      value: hre.ethers.utils.defaultAbiCoder.encode(
-        ['bytes4'],
-        [dapiServer.interface.getSighash('conditionPspBeaconUpdate')]
-      ),
-    },
-    { type: 'bytes', name: '_conditionParameters', value: beaconUpdateSubscriptionConditionParameters3 },
-  ];
-  const encodedBeaconUpdateSubscriptionConditionsLTC = abi.encode(beaconUpdateSubscriptionConditionsLTC);
-  await dapiServer
-    .connect(roles.randomPerson)
-    .registerBeaconUpdateSubscription(
-      airnodeWallet.address,
-      templateIdLTC,
-      encodedBeaconUpdateSubscriptionConditionsLTC,
-      airnodeWallet.address,
-      roles.sponsor.address
-    );
-
   // Update beacons with starting values
-  const apiValueETH = Math.floor(723.39202 * 1_000_000);
+  const apiValueETHInitial = Math.floor(723.39202 * 1_000_000);
+  const apiValueETH = Math.floor(738.149047 * 1_000_000);
   const apiValueBTC = Math.floor(41_091.12345 * 1_000_000);
   const apiValueLTC = Math.floor(51.42 * 1_000_000);
-  // ETH subscription
-  await updateBeacon(dapiServer, airnodePspSponsorWallet, airnodeWallet, subscriptionIdETH, apiValueETH);
-  // BTC subscription
-  await updateBeacon(dapiServer, airnodePspSponsorWallet, airnodeWallet, subscriptionIdBTC, apiValueBTC);
-  // LTC subscription
-  // await updateBeacon(dapiServer, airnodePspSponsorWallet, airnodeWallet, subscriptionIdLTC, apiValueLTC);
-  const signedDataValueETH = hre.ethers.utils.defaultAbiCoder.encode(
-    ['uint224'],
-    [hre.ethers.BigNumber.from('738149047')]
-  );
-  const { timestamp: signedDataTimestampETH, signature: signedDataSignatureETH } = await signData(
+
+  await updateBeacon(dapiServer, airnodeWallet, airseekerSponsorWallet, templateIdETH, apiValueETHInitial);
+  await updateBeacon(dapiServer, airnodeWallet, airseekerSponsorWallet, templateIdBTC, apiValueBTC);
+
+  const signedDataETH = await signData(
     airnodeWallet,
     templateIdETH,
-    signedDataValueETH
+    (await provider.getBlock('latest')).timestamp + 100,
+    apiValueETH
   );
-  const signedDataETH = {
-    timestamp: signedDataTimestampETH.toString(),
-    encodedValue: signedDataValueETH,
-    signature: signedDataSignatureETH,
-  };
-  const signedDataValueBTC = hre.ethers.utils.defaultAbiCoder.encode(
-    ['uint224'],
-    [hre.ethers.BigNumber.from(apiValueBTC)]
-  );
-  const { timestamp: signedDataTimestampBTC, signature: signedDataSignatureBTC } = await signData(
+
+  const signedDataBTC = await signData(
     airnodeWallet,
     templateIdBTC,
-    signedDataValueBTC
+    (await provider.getBlock('latest')).timestamp + 100,
+    apiValueBTC
   );
-  const signedDataBTC = {
-    timestamp: signedDataTimestampBTC.toString(),
-    encodedValue: signedDataValueBTC,
-    signature: signedDataSignatureBTC,
-  };
-  const signedDataValueLTC = hre.ethers.utils.defaultAbiCoder.encode(
-    ['uint224'],
-    [hre.ethers.BigNumber.from(apiValueLTC)]
-  );
-  const { timestamp: signedDataTimestampLTC, signature: signedDataSignatureLTC } = await signData(
+
+  const signedDataLTC = await signData(
     airnodeWallet,
     templateIdLTC,
-    signedDataValueLTC
+    (await provider.getBlock('latest')).timestamp + 100,
+    apiValueLTC
   );
-  const signedDataLTC = {
-    timestamp: signedDataTimestampLTC.toString(),
-    encodedValue: signedDataValueLTC,
-    signature: signedDataSignatureLTC,
-  };
 
   const beaconIdETH = hre.ethers.utils.keccak256(
     hre.ethers.utils.solidityPack(['address', 'bytes32'], ['0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace', templateIdETH])
@@ -320,7 +195,7 @@ export const deployAndUpdateSubscriptions = async () => {
 
   // BeaconSet update
   const tx = await dapiServer
-    .connect(airnodePspSponsorWallet)
+    .connect(airseekerSponsorWallet)
     .updateBeaconSetWithBeacons([beaconIdETH, beaconIdBTC], { gasLimit: 500_000 });
   await tx.wait();
 
@@ -333,15 +208,12 @@ export const deployAndUpdateSubscriptions = async () => {
     accessControlRegistry,
     airnodeProtocolFactory,
     airnodeProtocol,
-    dapiServerFactory,
+    api3ServerV1Factory,
     dapiServer,
     templateIdETH,
     templateIdBTC,
     templateIdLTC,
-    airnodePspSponsorWallet,
     airnodeWallet,
-    subscriptionIdETH,
-    subscriptionIdBTC,
     signedDataETH,
     signedDataBTC,
     signedDataLTC,

--- a/test/setup/deployment.ts
+++ b/test/setup/deployment.ts
@@ -1,3 +1,5 @@
+import * as hre from 'hardhat';
+import '@nomiclabs/hardhat-ethers';
 import * as abi from '@api3/airnode-abi';
 import * as node from '@api3/airnode-node';
 import * as protocol from '@api3/airnode-protocol';
@@ -5,9 +7,7 @@ import {
   AccessControlRegistry__factory as AccessControlRegistryFactory,
   Api3ServerV1__factory as Api3ServerV1Factory,
 } from '@api3/airnode-protocol-v1';
-import '@nomiclabs/hardhat-ethers';
 import { Contract, Wallet } from 'ethers';
-import * as hre from 'hardhat';
 import { SignedData } from '../../src/validation';
 import { buildLocalConfigBTC, buildLocalConfigETH, buildLocalConfigLTC } from '../fixtures/config';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,10 +74,10 @@
     yargs "^17.5.1"
     zod "^3.17.3"
 
-"@api3/airnode-protocol-v1@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@api3/airnode-protocol-v1/-/airnode-protocol-v1-1.1.2.tgz#8585aff94783923391d6efa593dbc92ce785eb24"
-  integrity sha512-mew8P3Ob3KKDwXtgs5P1SNHJirIwW1QeFk5trDiEw5dpeT36hT5SFUO9OcpujU3A+Hy3K0hXnHlwReStTtZJ9A==
+"@api3/airnode-protocol-v1@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@api3/airnode-protocol-v1/-/airnode-protocol-v1-1.2.4.tgz#c799ab5b0398f94b85334f0ecd98dc7940c03b5a"
+  integrity sha512-5QB+e/4CNmtkVAZERaEXkUttbjCUMOwqpaYUZdtuzbEXXoXQ2hWo+bTJNZ5bYhpphlLQULLbqje6s5oN1CTUuw==
   dependencies:
     "@openzeppelin/contracts" "4.8.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,12 +74,12 @@
     yargs "^17.5.1"
     zod "^3.17.3"
 
-"@api3/airnode-protocol-v1@^1.0.0-alpha.0":
-  version "1.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@api3/airnode-protocol-v1/-/airnode-protocol-v1-1.0.0-alpha.0.tgz#aede09391cecc592effe9ca9ba6e88e76698f0d1"
-  integrity sha512-tTfMEwxgzf+mH7CcdYIDlpJzl+yApzI5W1Qe7NE2gqMJqGTkSpQUAtcW01uNFwR5UihkAsPI3fCAJWm4Vu7fpw==
+"@api3/airnode-protocol-v1@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@api3/airnode-protocol-v1/-/airnode-protocol-v1-1.1.2.tgz#8585aff94783923391d6efa593dbc92ce785eb24"
+  integrity sha512-mew8P3Ob3KKDwXtgs5P1SNHJirIwW1QeFk5trDiEw5dpeT36hT5SFUO9OcpujU3A+Hy3K0hXnHlwReStTtZJ9A==
   dependencies:
-    "@openzeppelin/contracts" "4.8.0"
+    "@openzeppelin/contracts" "4.8.2"
 
 "@api3/airnode-protocol@^0.8.0":
   version "0.8.0"
@@ -1578,10 +1578,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
   integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
 
-"@openzeppelin/contracts@4.8.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.0.tgz#6854c37df205dd2c056bdfa1b853f5d732109109"
-  integrity sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==
+"@openzeppelin/contracts@4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.2.tgz#d815ade0027b50beb9bcca67143c6bcc3e3923d6"
+  integrity sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g==
 
 "@pm2/agent@~2.0.0":
   version "2.0.1"


### PR DESCRIPTION
Closes #351 

- Updated airnode-protocol-v1 package to version 1.1.2
- ~~Added new update condition that checks value of fulfillment data is changed compared to on-chain record~~
- Because the feature `updating Beacon sets with signed data` is deprecated,  I refactored the current implementation to use the function `updateBeaconSetWithBeacons`.  Even though this implementation is working under e2e test, it is probably incomplete. Instead of removing Beacon set updates, I did this refactoring, because it'll be helpful while we are updating the function `updateBeaconSets` in near future.
- Refactored e2e tests not to use deprecated update protocol PSP which is used while initializing test beacons
- Renamed `DapiServer` to `Api3ServerV1`, thanks a lot @acenolaza 