### PR TITLE
Bump serverless.aws.yml Node version to 18

### DIFF
--- a/serverless.aws.yml
+++ b/serverless.aws.yml
@@ -11,7 +11,7 @@ provider:
   name: aws
   region: us-east-1
   stage: '2209221310'
-  runtime: nodejs14.x
+  runtime: nodejs18.x
   architecture: arm64
   logRetentionInDays: 14
   environment: ${file(scripts/load-secrets-env.js)}


### PR DESCRIPTION
Good catch @bdrhn9, this closes #384 by updating serverless.aws.yml to Node 18, in line with package.json:

https://github.com/api3dao/airseeker/blob/b0c513e8274ba48af1bb2c424a3e7e9bdb2f8bd5/package.json#L20

For reference, Airnode's [terraform config](https://github.com/api3dao/airnode/blob/2a46fe06d6533f87b0676a9c69e95feb9f5233e8/packages/airnode-deployer/terraform/aws/modules/function/main.tf#LL46C8-L46C8) has had Node 18 for a bit now.