### PR TITLE
Force updating all children in beacon sets if parent requires an update

### DIFF
--- a/src/update-data-feeds.ts
+++ b/src/update-data-feeds.ts
@@ -495,28 +495,17 @@ export const updateBeaconSets = async (providerSponsorDataFeeds: ProviderSponsor
             break;
           }
 
-          // Verify all conditions for beacon update are met
-          // If condition check returns true then beacon update is required
-          const [log, result] = checkConditions(
-            onChainBeaconValue,
-            onChainBeaconTimestamp,
-            parseInt(apiBeaconResponse.timestamp, 10),
-            beaconSetUpdateData.beaconSetTrigger,
-            decodedValue
-          );
-          logger.logPending(log, logOptionsBeaconId);
           const { airnode, templateId } = config.beacons[beaconId];
-          if (result) {
-            value = decodedValue;
-            timestamp = parseInt(apiBeaconResponse.timestamp, 10);
-            calldata = contract.interface.encodeFunctionData('updateBeaconWithSignedData', [
-              airnode,
-              templateId,
-              apiBeaconResponse.timestamp,
-              apiBeaconResponse.encodedValue,
-              apiBeaconResponse.signature,
-            ]);
-          }
+
+          value = decodedValue;
+          timestamp = parseInt(apiBeaconResponse.timestamp, 10);
+          calldata = contract.interface.encodeFunctionData('updateBeaconWithSignedData', [
+            airnode,
+            templateId,
+            apiBeaconResponse.timestamp,
+            apiBeaconResponse.encodedValue,
+            apiBeaconResponse.signature,
+          ]);
         }
 
         beaconSetBeaconUpdateData = {


### PR DESCRIPTION
See discussion on Slack [here](https://api3workspace.slack.com/archives/C037NLX1R8T/p1690541486061689).

This PR removes the condition check for updating beacons in beacon sets / if a beacon set needs to be updated all children should be updated.