### PR TITLE
Support undefined fulfillment gas limit

### DIFF
--- a/src/update-data-feeds.ts
+++ b/src/update-data-feeds.ts
@@ -1,4 +1,4 @@
-import { Api3ServerV1__factory as Api3ServerV1Factory } from '@api3/airnode-protocol-v1';
+import { Api3ServerV1, Api3ServerV1__factory as Api3ServerV1Factory } from '@api3/airnode-protocol-v1';
 import { getGasPrice } from '@api3/airnode-utilities';
 import { go } from '@api3/promise-utils';
 import { ethers } from 'ethers';
@@ -15,7 +15,7 @@ import {
 import { LogOptionsOverride, logger } from './logging';
 import { Provider, getState } from './state';
 import { getTransactionCount } from './transaction-count';
-import { prepareGoOptions, shortenAddress, sleep } from './utils';
+import { createDummyBeaconUpdateData, prepareGoOptions, shortenAddress, sleep } from './utils';
 import { Beacon, BeaconSetTrigger, BeaconTrigger, SignedData } from './validation';
 
 type ProviderSponsorDataFeeds = {
@@ -24,6 +24,15 @@ type ProviderSponsorDataFeeds = {
   updateInterval: number;
   beaconTriggers: BeaconTrigger[];
   beaconSetTriggers: BeaconSetTrigger[];
+};
+
+type BeaconUpdate = {
+  logOptionsBeaconId: LogOptionsOverride;
+  beaconTrigger: BeaconTrigger;
+  beacon: Beacon;
+  newBeaconResponse: SignedData;
+  newBeaconValue: ethers.BigNumber;
+  dataFeedsCalldata: string;
 };
 
 export enum DataFeedType {
@@ -168,6 +177,45 @@ export const initializeUpdateCycle = async (
   };
 };
 
+const estimateBeaconMulticallGasLimit = async (
+  contract: Api3ServerV1,
+  calldatas: string[],
+  logOptions: LogOptionsOverride
+) => {
+  const estimateGasMulticall = await go(() => contract.estimateGas.multicall(calldatas), {
+    retries: 1,
+  });
+  if (estimateGasMulticall.success) {
+    // Adding a extra 10% because multicall consumes less gas than tryMulticall
+    return estimateGasMulticall.data.mul(ethers.BigNumber.from(Math.round(1.1 * 100))).div(ethers.BigNumber.from(100));
+  }
+  logger.warn(`Unable to estimate gas for multicall: ${estimateGasMulticall.error}`, logOptions);
+
+  const estimateGasUpdateBeaconWithSignedData = await go(
+    async () => {
+      const { dummyAirnode, dummyBeaconTemplateId, dummyBeaconTimestamp, dummyBeaconData, dummyBeaconSignature } =
+        await createDummyBeaconUpdateData();
+      return contract.estimateGas.updateBeaconWithSignedData(
+        dummyAirnode.address,
+        dummyBeaconTemplateId,
+        dummyBeaconTimestamp,
+        dummyBeaconData,
+        dummyBeaconSignature
+      );
+    },
+    { retries: 1 }
+  );
+  if (estimateGasUpdateBeaconWithSignedData.success) {
+    return estimateGasUpdateBeaconWithSignedData.data.mul(calldatas.length);
+  }
+  logger.warn(
+    `Unable to estimate gas for updateBeaconWithSignedData: ${estimateGasUpdateBeaconWithSignedData.error}`,
+    logOptions
+  );
+
+  return ethers.BigNumber.from(2_000_000);
+};
+
 // We pass return value from `prepareGoOptions` (with calculated timeout) to every `go` call in the function to enforce the update cycle.
 // This solution is not precise but since chain operations are the only ones that actually take some time this should be a good enough solution.
 export const updateBeacons = async (providerSponsorDataFeeds: ProviderSponsorDataFeeds, startTime: number) => {
@@ -186,15 +234,6 @@ export const updateBeacons = async (providerSponsorDataFeeds: ProviderSponsorDat
     provider,
   } = initialUpdateData;
   const { chainId } = provider;
-
-  type BeaconUpdate = {
-    logOptionsBeaconId: LogOptionsOverride;
-    beaconTrigger: BeaconTrigger;
-    beacon: Beacon;
-    newBeaconResponse: SignedData;
-    newBeaconValue: ethers.BigNumber;
-    dataFeedsCalldata: string;
-  };
 
   // Process beacon read calldatas
   const beaconUpdates = beaconTriggers.reduce((acc: BeaconUpdate[], beaconTrigger) => {
@@ -291,7 +330,6 @@ export const updateBeacons = async (providerSponsorDataFeeds: ProviderSponsorDat
 
     let nonce = transactionCount;
     for (const updateBatch of chunk(beaconUpdates, DATAFEED_UPDATE_BATCH_SIZE)) {
-      // Get the latest gas price
       const getGasFn = () => getGasPrice(provider.rpcProvider.getProvider(), config.chains[chainId].options);
       // We have to grab the limiter from the custom provider as the getGasPrice function contains its own timeouts
       const [logs, gasTarget] = await provider.rpcProvider.getLimiter().schedule({ expiration: 30_000 }, getGasFn);
@@ -319,19 +357,27 @@ export const updateBeacons = async (providerSponsorDataFeeds: ProviderSponsorDat
                   beaconUpdates[0].newBeaconResponse.signature,
                   { nonce, ...gasTarget }
                 )
-          : () => {
-              return contract.connect(sponsorWallet).tryMulticall(
-                updateBatch.map((beaconUpdateData) =>
-                  contract.interface.encodeFunctionData('updateBeaconWithSignedData', [
-                    beaconUpdateData.beacon.airnode,
-                    beaconUpdateData.beacon.templateId,
-                    beaconUpdateData.newBeaconResponse.timestamp,
-                    beaconUpdateData.newBeaconResponse.encodedValue,
-                    beaconUpdateData.newBeaconResponse.signature,
-                  ])
-                ),
-                { nonce, ...gasTarget }
+          : async () => {
+              const calldatas = updateBatch.map((beaconUpdateData) =>
+                contract.interface.encodeFunctionData('updateBeaconWithSignedData', [
+                  beaconUpdateData.beacon.airnode,
+                  beaconUpdateData.beacon.templateId,
+                  beaconUpdateData.newBeaconResponse.timestamp,
+                  beaconUpdateData.newBeaconResponse.encodedValue,
+                  beaconUpdateData.newBeaconResponse.signature,
+                ])
               );
+
+              const gasLimit =
+                gasTarget.gasLimit ??
+                (await estimateBeaconMulticallGasLimit(contract.connect(sponsorWallet), calldatas, logOptions));
+              logger.debug(`Gas limit: ${gasLimit.toString()}`, logOptions);
+
+              return contract.connect(sponsorWallet).tryMulticall(calldatas, {
+                nonce,
+                ...gasTarget,
+                gasLimit,
+              });
             },
         {
           ...prepareGoOptions(startTime, totalTimeout),
@@ -358,6 +404,49 @@ export const updateBeacons = async (providerSponsorDataFeeds: ProviderSponsorDat
       nonce++;
     }
   }
+};
+
+const estimateBeaconSetMulticallGasLimit = async (
+  contract: Api3ServerV1,
+  calldatas: string[],
+  beaconIds: string[],
+  logOptions: LogOptionsOverride
+) => {
+  const estimateGasMulticall = await go(() => contract.estimateGas.multicall(calldatas), { retries: 1 });
+  if (estimateGasMulticall.success) {
+    // Adding a extra 10% because multicall consumes less gas than tryMulticall
+    return estimateGasMulticall.data.mul(ethers.BigNumber.from(Math.round(1.1 * 100))).div(ethers.BigNumber.from(100));
+  }
+  logger.warn(`Unable to estimate gas for multicall: ${estimateGasMulticall.error}`, logOptions);
+
+  const estimatedGas = await go(
+    async () => {
+      const { dummyAirnode, dummyBeaconTemplateId, dummyBeaconTimestamp, dummyBeaconData, dummyBeaconSignature } =
+        await createDummyBeaconUpdateData();
+      return [
+        await contract.estimateGas.updateBeaconWithSignedData(
+          dummyAirnode.address,
+          dummyBeaconTemplateId,
+          dummyBeaconTimestamp,
+          dummyBeaconData,
+          dummyBeaconSignature
+        ),
+        await contract.estimateGas.updateBeaconSetWithBeacons(beaconIds),
+      ];
+    },
+    { retries: 1 }
+  );
+  if (estimatedGas.success) {
+    const [estimatedGasUpdateBeaconWithSignedData, estimatedGasUpdateBeaconSetWithBeacons] = estimatedGas.data;
+
+    return estimatedGasUpdateBeaconWithSignedData.mul(beaconIds.length).add(estimatedGasUpdateBeaconSetWithBeacons);
+  }
+  logger.warn(
+    `Unable to estimate gas for updateBeaconWithSignedData and updateBeaconWithSignedData: ${estimatedGas.error}`,
+    logOptions
+  );
+
+  return ethers.BigNumber.from(2_000_000);
 };
 
 // We pass return value from `prepareGoOptions` (with calculated timeout) to every `go` call in the function to enforce the update cycle.
@@ -424,8 +513,13 @@ export const updateBeaconSets = async (providerSponsorDataFeeds: ProviderSponsor
     }
     const { successes, returndata } = goDatafeedsTryMulticall.data;
 
-    // Process beacon set update calldatas
-    let beaconSetUpdateCalldatas: string[][] = [];
+    type BeaconSetBeaconUpdate = {
+      beaconId: string;
+    } & Pick<Beacon, 'airnode' | 'templateId'> &
+      SignedData;
+
+    // Process beacon set update
+    let beaconSetsBeaconUpdates: BeaconSetBeaconUpdate[][] = [];
 
     for (let i = 0; i < readBatch.length; i++) {
       const beaconSetReturndata = returndata[i];
@@ -474,18 +568,18 @@ export const updateBeaconSets = async (providerSponsorDataFeeds: ProviderSponsor
 
       type BeaconSetBeaconUpdateData = {
         // These values are used to calculate the median value and timestamp prior to beacon set condition checks
-        beaconSetBeaconValues: {
+        beaconValues: {
           value: ethers.BigNumber;
           timestamp: number;
         }[];
-        // This array contains all the calldatas for updating beacon values
-        updateBeaconWithSignedDataCalldatas: string[];
+        // This array contains all data for updating beacon set beacons with signed data
+        beaconUpdates: BeaconSetBeaconUpdate[];
       };
 
       // Process each beacon in the current beacon set
       let beaconSetBeaconUpdateData: BeaconSetBeaconUpdateData = {
-        beaconSetBeaconValues: [],
-        updateBeaconWithSignedDataCalldatas: [],
+        beaconValues: [],
+        beaconUpdates: [],
       };
       let shouldSkipBeaconSetUpdate = false;
       for (let i = 0; i < beaconSetBeaconIds.length; i++) {
@@ -519,7 +613,7 @@ export const updateBeaconSets = async (providerSponsorDataFeeds: ProviderSponsor
 
         let value = onChainBeaconValue;
         let timestamp = onChainBeaconTimestamp;
-        let calldata = undefined;
+        let beaconUpdate: BeaconSetBeaconUpdate | null = null;
         if (apiBeaconResponse) {
           // There is a new beacon value in the API response
           const decodedValue = decodeBeaconValue(apiBeaconResponse.encodedValue);
@@ -534,21 +628,17 @@ export const updateBeaconSets = async (providerSponsorDataFeeds: ProviderSponsor
 
           value = decodedValue;
           timestamp = parseInt(apiBeaconResponse.timestamp, 10);
-          calldata = contract.interface.encodeFunctionData('updateBeaconWithSignedData', [
+          beaconUpdate = {
+            beaconId,
             airnode,
             templateId,
-            apiBeaconResponse.timestamp,
-            apiBeaconResponse.encodedValue,
-            apiBeaconResponse.signature,
-          ]);
+            ...apiBeaconResponse,
+          };
         }
 
         beaconSetBeaconUpdateData = {
-          beaconSetBeaconValues: [...beaconSetBeaconUpdateData.beaconSetBeaconValues, { value, timestamp }],
-          updateBeaconWithSignedDataCalldatas: [
-            ...beaconSetBeaconUpdateData.updateBeaconWithSignedDataCalldatas,
-            ...(calldata ? [calldata] : []),
-          ],
+          beaconValues: [...beaconSetBeaconUpdateData.beaconValues, { value, timestamp }],
+          beaconUpdates: [...beaconSetBeaconUpdateData.beaconUpdates, ...(beaconUpdate ? [beaconUpdate] : [])],
         };
       }
       if (shouldSkipBeaconSetUpdate) {
@@ -557,11 +647,9 @@ export const updateBeaconSets = async (providerSponsorDataFeeds: ProviderSponsor
       }
 
       // https://github.com/api3dao/airnode-protocol-v1/blob/main/contracts/api3-server-v1/DataFeedServer.sol#L163
-      const newBeaconSetValue = calculateMedian(
-        beaconSetBeaconUpdateData.beaconSetBeaconValues.map((value) => value.value)
-      );
+      const newBeaconSetValue = calculateMedian(beaconSetBeaconUpdateData.beaconValues.map((value) => value.value));
       const newBeaconSetTimestamp = calculateMedian(
-        beaconSetBeaconUpdateData.beaconSetBeaconValues.map((value) => ethers.BigNumber.from(value.timestamp))
+        beaconSetBeaconUpdateData.beaconValues.map((value) => ethers.BigNumber.from(value.timestamp))
       ).toNumber();
 
       // Verify all conditions for beacon set update are met otherwise skip
@@ -577,28 +665,48 @@ export const updateBeaconSets = async (providerSponsorDataFeeds: ProviderSponsor
         continue;
       }
 
-      beaconSetUpdateCalldatas = [
-        ...beaconSetUpdateCalldatas,
-        [
-          ...beaconSetBeaconUpdateData.updateBeaconWithSignedDataCalldatas,
-          // All beaconSet beaconIds must be passed in as an array because
-          // the contract function derives the beaconSetId based on the beaconIds
-          contract.interface.encodeFunctionData('updateBeaconSetWithBeacons', [beaconSetBeaconIds]),
-        ],
-      ];
+      beaconSetsBeaconUpdates = [...beaconSetsBeaconUpdates, beaconSetBeaconUpdateData.beaconUpdates];
     }
 
     let nonce = transactionCount;
-    for (const beaconSetUpdateCalldata of beaconSetUpdateCalldatas) {
-      // Get the latest gas price
+    // For beacon sets, we send a single transaction per beacon set by multicalling the update of each beacon plus the beacon set update
+    for (const beaconSetBeaconUpdates of beaconSetsBeaconUpdates) {
       const getGasFn = () => getGasPrice(provider.rpcProvider.getProvider(), config.chains[chainId].options);
       // We have to grab the limiter from the custom provider as the getGasPrice function contains its own timeouts
       const [logs, gasTarget] = await provider.rpcProvider.getLimiter().schedule({ expiration: 30_000 }, getGasFn);
       logger.logPending(logs, logOptions);
 
+      const beaconIds = beaconSetBeaconUpdates.map((beaconSetBeaconUpdate) => beaconSetBeaconUpdate.beaconId);
+      const beaconSetUpdateCalldatas = [
+        ...beaconSetBeaconUpdates.map((beaconSetBeaconUpdate) =>
+          contract.interface.encodeFunctionData('updateBeaconWithSignedData', [
+            beaconSetBeaconUpdate.airnode,
+            beaconSetBeaconUpdate.templateId,
+            beaconSetBeaconUpdate.timestamp,
+            beaconSetBeaconUpdate.encodedValue,
+            beaconSetBeaconUpdate.signature,
+          ])
+        ),
+        contract.interface.encodeFunctionData('updateBeaconSetWithBeacons', [beaconIds]),
+      ];
+
       // Update beacon set batch onchain values
       const tx = await go(
-        () => contract.connect(sponsorWallet).tryMulticall(beaconSetUpdateCalldata, { nonce, ...gasTarget }),
+        async () => {
+          const gasLimit =
+            gasTarget.gasLimit ??
+            (await estimateBeaconSetMulticallGasLimit(
+              contract.connect(sponsorWallet),
+              beaconSetUpdateCalldatas,
+              beaconIds,
+              logOptions
+            ));
+          logger.debug(`Gas limit: ${gasLimit.toString()}`, logOptions);
+
+          return contract
+            .connect(sponsorWallet)
+            .tryMulticall(beaconSetUpdateCalldatas, { nonce, ...gasTarget, gasLimit });
+        },
         {
           ...prepareGoOptions(startTime, totalTimeout),
           onAttemptError: (goError) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { GoAsyncOptions } from '@api3/promise-utils';
+import { ethers } from 'ethers';
 import { RANDOM_BACKOFF_MAX_MS, RANDOM_BACKOFF_MIN_MS } from './constants';
 
 export const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
@@ -10,3 +11,23 @@ export const calculateTimeout = (startTime: number, totalTimeout: number) => tot
 export const prepareGoOptions = (_startTime: number, _totalTimeout: number): GoAsyncOptions => ({
   delay: { type: 'random' as const, minDelayMs: RANDOM_BACKOFF_MIN_MS, maxDelayMs: RANDOM_BACKOFF_MAX_MS },
 });
+
+export const createDummyBeaconUpdateData = async (dummyAirnode: ethers.Wallet = ethers.Wallet.createRandom()) => {
+  const dummyBeaconTemplateId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+  const dummyBeaconTimestamp = Math.floor(Date.now() / 1000);
+  const randomBytes = ethers.utils.randomBytes(Math.floor(Math.random() * 27) + 1);
+  const dummyBeaconData = ethers.utils.defaultAbiCoder.encode(
+    ['int224'],
+    // Any radom number that fits into an int224
+    [ethers.BigNumber.from(randomBytes)]
+  );
+  const dummyBeaconSignature = await dummyAirnode.signMessage(
+    ethers.utils.arrayify(
+      ethers.utils.solidityKeccak256(
+        ['bytes32', 'uint256', 'bytes'],
+        [dummyBeaconTemplateId, dummyBeaconTimestamp, dummyBeaconData]
+      )
+    )
+  );
+  return { dummyAirnode, dummyBeaconTemplateId, dummyBeaconTimestamp, dummyBeaconData, dummyBeaconSignature };
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export const createDummyBeaconUpdateData = async (dummyAirnode: ethers.Wallet = 
   const randomBytes = ethers.utils.randomBytes(Math.floor(Math.random() * 27) + 1);
   const dummyBeaconData = ethers.utils.defaultAbiCoder.encode(
     ['int224'],
-    // Any radom number that fits into an int224
+    // Any random number that fits into an int224
     [ethers.BigNumber.from(randomBytes)]
   );
   const dummyBeaconSignature = await dummyAirnode.signMessage(

--- a/test/e2e/update-data-feeds.feature.ts
+++ b/test/e2e/update-data-feeds.feature.ts
@@ -47,15 +47,10 @@ describe('updateDataFeeds', () => {
   });
 
   it('updates data feeds based on the configuration', async () => {
-    initiateDataFeedUpdates();
-    await utils.sleep(8_000);
-    state.updateState((oldState) => ({ ...oldState, stopSignalReceived: true }));
-    await utils.sleep(8_000);
-
     const beaconDataETH = await api3ServerV1
       .connect(voidSigner)
       .dataFeeds('0x924b5d4cb3ec6366ae4302a1ca6aec035594ea3ea48a102d160b50b0c43ebfb5');
-    expect(beaconDataETH.value.toString()).toEqual('738149047');
+    expect(beaconDataETH.value.toString()).toEqual('723392020');
     const beaconDataBTC = await api3ServerV1
       .connect(voidSigner)
       .dataFeeds('0xbf7ce55d109fd196de2a8bf1515d166c56c9decbe9cb473656bbca30d5743990');
@@ -63,11 +58,33 @@ describe('updateDataFeeds', () => {
     const beaconDataLTC = await api3ServerV1
       .connect(voidSigner)
       .dataFeeds('0x9b5825decf1232f79d3408fb6f7eeb7050fd88037f6517a94914e7d01ccd0cef');
-    expect(beaconDataLTC.value.toString()).toEqual('51420000');
+    expect(beaconDataLTC.value.toString()).toEqual('0');
     const beaconSetData = await api3ServerV1
       .connect(voidSigner)
       .dataFeeds('0xf7f1620b7f422eb9a69c8e21b317ba1555d3d87e1d804f0b024f03b107e411e8');
-    expect(beaconSetData.value.toString()).toEqual('20914636248');
+    expect(beaconSetData.value.toString()).toEqual('20907257735');
+
+    initiateDataFeedUpdates();
+    await utils.sleep(8_000);
+    state.updateState((oldState) => ({ ...oldState, stopSignalReceived: true }));
+    await utils.sleep(8_000);
+
+    const beaconDataETHNew = await api3ServerV1
+      .connect(voidSigner)
+      .dataFeeds('0x924b5d4cb3ec6366ae4302a1ca6aec035594ea3ea48a102d160b50b0c43ebfb5');
+    expect(beaconDataETHNew.value.toString()).toEqual('738149047');
+    const beaconDataBTCNew = await api3ServerV1
+      .connect(voidSigner)
+      .dataFeeds('0xbf7ce55d109fd196de2a8bf1515d166c56c9decbe9cb473656bbca30d5743990');
+    expect(beaconDataBTCNew.value.toString()).toEqual('41091123450');
+    const beaconDataLTCNew = await api3ServerV1
+      .connect(voidSigner)
+      .dataFeeds('0x9b5825decf1232f79d3408fb6f7eeb7050fd88037f6517a94914e7d01ccd0cef');
+    expect(beaconDataLTCNew.value.toString()).toEqual('51420000');
+    const beaconSetDataNew = await api3ServerV1
+      .connect(voidSigner)
+      .dataFeeds('0xf7f1620b7f422eb9a69c8e21b317ba1555d3d87e1d804f0b024f03b107e411e8');
+    expect(beaconSetDataNew.value.toString()).toEqual('20914636248');
   });
 
   // TODO: Add more tests


### PR DESCRIPTION
Closes #447 

I'm basically doing the following:

1. check if `fulfillmentGasLimit` exist in the config
2. if it doesn't then estimate the gas limit
2.1. estimate based on Api3ServerV1.multicall (tryMulticall estimate is usually wrong). If successful then add an extra since tryMulticall is a bit more expensive
2.2. if previous failed, estimate based on a single beacon update using dummy data (for beacon set update we add up the estimate of updating all beacon plus the beaconSet)
2.3. if both previous failed then just return a hardcoded gas limit  of 2_000_000

This is still a draft because I need to fix/add some tests and do some minor cleanup/refactor