### PR TITLE
Increase limits on OpsGenie integration

### DIFF
--- a/src/alerting.ts
+++ b/src/alerting.ts
@@ -99,7 +99,10 @@ export type NodaryPayload = {
 };
 
 // Mocking the OpsGenie utils for tests can be a pain - this assists us
-let { limitedCloseOpsGenieAlertWithAlias, limitedSendToOpsGenieLowLevel } = utils.getOpsGenieLimiter();
+let { limitedCloseOpsGenieAlertWithAlias, limitedSendToOpsGenieLowLevel } = utils.getOpsGenieLimiter({
+  maxConcurrent: 5,
+  minTime: 10,
+});
 export { limitedCloseOpsGenieAlertWithAlias, limitedSendToOpsGenieLowLevel };
 
 export const opsGenieConfig = { apiKey: process.env.OPSGENIE_API_KEY ?? '', responders: [] };


### PR DESCRIPTION
Closes https://github.com/api3dao/tasks/issues/380

This PR increases the Bottleneck limits on OpsGenie API calls. The default is a concurrency of 1 with a minTime of 500ms, which is effectively 2 Hz. 

[A few weeks later(!)] This has been running for some time now and everything looks good, sao safe to merge.