### PR TITLE
Fix config parsing temporarily

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ type Secrets = Record<string, string | undefined>;
 
 export const loadConfig = (configPath: string, secrets: Record<string, string | undefined>) => {
   const rawConfig = readConfig(configPath);
-  // @ts-ignore
+  // @ts-ignore eslint-disable-next-line functional/immutable-data
   rawConfig.chains = Object.fromEntries(
     // @ts-ignore
     Object.entries(rawConfig.chains).map(([chainId, chainData]) => [

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,10 @@ type Secrets = Record<string, string | undefined>;
 
 export const loadConfig = (configPath: string, secrets: Record<string, string | undefined>) => {
   const rawConfig = readConfig(configPath);
-  // @ts-ignore eslint-disable-next-line functional/immutable-data
+
+  // Hack to deal with missing fulfilment limits without bumping dependencies
+  // @ts-ignore
+  // eslint-disable-next-line functional/immutable-data
   rawConfig.chains = Object.fromEntries(
     // @ts-ignore
     Object.entries(rawConfig.chains).map(([chainId, chainData]) => [

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,20 @@ type Secrets = Record<string, string | undefined>;
 
 export const loadConfig = (configPath: string, secrets: Record<string, string | undefined>) => {
   const rawConfig = readConfig(configPath);
+  // @ts-ignore
+  rawConfig.chains = Object.fromEntries(
+    // @ts-ignore
+    Object.entries(rawConfig.chains).map(([chainId, chainData]) => [
+      chainId,
+      {
+        // @ts-ignore
+        ...chainData,
+        // @ts-ignore
+        options: { ...chainData.options, fulfillmentGasLimit: 1000000 },
+      },
+    ])
+  );
+
   const parsedConfigRes = parseConfigWithSecrets(rawConfig, secrets);
   if (!parsedConfigRes.success) {
     throw new Error(`Invalid Airseeker configuration file: ${parsedConfigRes.error}`);


### PR DESCRIPTION
This is a hack to deal with an unset fulfilment limit.
The correct way of dealing with this is to bump dependencies, but doing that would entail a lot of work and we don't expect this app to be used in two months time, so adding in this hack to fix the issues seems like a reasonable approach.

Closes https://github.com/api3dao/tasks/issues/579